### PR TITLE
Make deep copy of model before modification

### DIFF
--- a/flumodelingsuite/school_closures.py
+++ b/flumodelingsuite/school_closures.py
@@ -250,6 +250,10 @@ def add_school_closure_interventions(
     import pandas as pd
     import sys
     import os
+    import copy
+
+    # Make a deep copy of the model to avoid modifying the original
+    model = copy.deepcopy(model)
 
     # Codebook for locations
     filename = os.path.join(os.path.dirname(sys.modules[__name__].__file__), "data/location_codebook.csv")

--- a/flumodelingsuite/vaccinations.py
+++ b/flumodelingsuite/vaccinations.py
@@ -484,6 +484,10 @@ def add_vaccination_schedule(
 
     import os
     import sys
+    import copy
+
+    # Make a deep copy of the model to avoid modifying the original
+    model = copy.deepcopy(model)
 
     model_location = model.population.name
 
@@ -533,6 +537,11 @@ def remove_vaccination_transitions(model, source_comp, target_comp):
         `add_vaccination_schedule` from creating duplicate transitions
         if it is called multiple times.
         """
+
+        import copy
+
+        # Make a deep copy of the model to avoid modifying the original
+        model = copy.deepcopy(model)
         
         # Remove from transitions_list
         model.transitions_list = [


### PR DESCRIPTION
## Changes
- Make deep copies of model to avoid modifying the original. Applied to:
    - `add_vaccination_schedule()`
    - `remove_vaccination_transitions()`
    - `add_school_closure_interventions()`

Resolves #9 
