### PR TITLE
Fix date default_factory in Meta model

### DIFF
--- a/flumodelingsuite/validation/common_validators.py
+++ b/flumodelingsuite/validation/common_validators.py
@@ -46,5 +46,5 @@ class Meta(BaseModel):
     author: str | None = Field(None, description="Author of the experiment / configurations.")
     version: str | float | None = Field(None, description="Version of the experiment / configurations.")
     date: datetime.date | datetime.datetime | None = Field(
-        default_factory=datetime.datetime.now(tz=datetime.timezone.utc), description="Date of work"
+        default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc), description="Date of work"
     )


### PR DESCRIPTION
### Summary

Fixed a bug in the `Meta` model where the `date` field's `default_factory` was incorrectly calling `datetime.datetime.now()` immediately instead of passing a callable. This caused Pydantic validation to fail with the error: `'datetime.datetime' object is not callable`.

### Problem

In `common_validators.py`, the `date` field was defined as:

```python
date: datetime.date | datetime.datetime | None = Field(
    default_factory=datetime.datetime.now(tz=datetime.timezone.utc), description="Date of work"
)
```

The issue is that `datetime.datetime.now(tz=datetime.timezone.utc)` executes immediately and returns a datetime object. Pydantic's default_factory parameter expects a callable that it can invoke when needed, not a pre-computed value. When Pydantic attempted to call this datetime object to generate a default value, it resulted in a TypeError.

### Solution
Changed the default_factory to use a lambda function:
```python
date: datetime.date | datetime.datetime | None = Field(
    default_factory=lambda: datetime.datetime.now(tz=datetime.timezone.utc), description="Date of work"
)
```
Now Pydantic receives a proper callable that returns the current UTC datetime when invoked.
