### PR TITLE
Fix projection shape mismatch

### DIFF
--- a/flumodelingsuite/builders/orchestrators.py
+++ b/flumodelingsuite/builders/orchestrators.py
@@ -351,7 +351,8 @@ def make_simulate_wrapper(
             try:
                 results = simulate(**sim_params)
                 trajectory_dates = results.dates
-                data_dates = list(pd.to_datetime(data_state.target_end_date.values))
+                date_column = calibration.comparison[0].observed_date_column
+                data_dates = list(pd.to_datetime(data_state[date_column].values))
 
                 mask = [date in data_dates for date in trajectory_dates]
 
@@ -370,7 +371,8 @@ def make_simulate_wrapper(
                 failed_params = params.copy()
                 failed_params.pop("epimodel", None)
                 logger.info("Simulation failed with parameters %s: %s", failed_params, e)
-                data_dates = list(pd.to_datetime(data_state["target_end_date"].values))
+                date_column = calibration.comparison[0].observed_date_column
+                data_dates = list(pd.to_datetime(data_state[date_column].values))
                 simulated_data = np.full(len(data_dates), 0)
 
             return {"data": simulated_data}

--- a/tests/test_make_simulate_wrapper.py
+++ b/tests/test_make_simulate_wrapper.py
@@ -65,6 +65,7 @@ class TestMakeSimulateWrapper:
         calibration = Mock()
         calibration.comparison = [Mock()]
         calibration.comparison[0].simulation = ["S_to_I"]
+        calibration.comparison[0].observed_date_column = "target_end_date"
         return calibration
 
     @pytest.fixture


### PR DESCRIPTION
Resolves #87.

### Changes made
- Fix projection shape mismatch
  - Use `sampled_start_timespan.start_date` for projection
  - Change output data structure so that it works with np.stack()
- Minor refactoring
  - Renamed `total_hosp` to `simulated_data` for more generic naming
  - Replaced hardcoded "target_end_date" with user configured column name from YAML
  - Added comments for readability