### PR TITLE
Output dispatcher bug fix

### DIFF
--- a/flumodelingsuite/dispatcher/output.py
+++ b/flumodelingsuite/dispatcher/output.py
@@ -304,17 +304,13 @@ def generate_calibration_outputs(*, calibrations: list[CalibrationOutput], outpu
                             )
                             # Use all compartments, filter out transitions
                             transition_columns = [
-                                c
-                                for c in runner_output_calibration.results.get_projection_quantiles().columns
-                                if "_to_" in c
+                                c for c in calibration.results.get_projection_quantiles().columns if "_to_" in c
                             ]
                             quan_df.drop(columns=transition_columns, inplace=True)
                     else:
                         # Use all compartments, filter out transitions
                         transition_columns = [
-                            c
-                            for c in runner_output_calibration.results.get_projection_quantiles().columns
-                            if "_to_" in c
+                            c for c in calibration.results.get_projection_quantiles().columns if "_to_" in c
                         ]
                         quan_df.drop(columns=transition_columns, inplace=True)
                     quan_df.insert(0, "primary_id", calibration.primary_id)
@@ -341,18 +337,14 @@ def generate_calibration_outputs(*, calibrations: list[CalibrationOutput], outpu
                             )
                             # Use all transitions, filter out compartments
                             transition_columns = [
-                                c
-                                for c in runner_output_calibration.results.get_projection_quantiles().columns
-                                if "_to_" in c
+                                c for c in calibration.results.get_projection_quantiles().columns if "_to_" in c
                             ]
                             # TODO: add target prediction data column name below
                             quan_df = quan_df[["date", "quantile"] + transition_columns]
                     else:
                         # Use all transitions, filter out compartments
                         transition_columns = [
-                            c
-                            for c in runner_output_calibration.results.get_projection_quantiles().columns
-                            if "_to_" in c
+                            c for c in calibration.results.get_projection_quantiles().columns if "_to_" in c
                         ]
                         # TODO: add target prediction data column name below
                         quan_df = quan_df[["date", "quantile"] + transition_columns]


### PR DESCRIPTION
This PR fixes #96 and makes the output generator dispatcher work.

**Refactoring (which bug fixes work on top of)**
- Rename function parameters from singular to plural (`simulation` → `simulations`, `calibration` → `calib
rations`) for clarity
- Update registry keys to match new parameter names (`"simulation"` → `"simulations"`, `"calibration"` → `
"calibrations"`)
- Refactor loop variables from generic `model` to specific `simulation`/`calibration` to avoid confusion
with EpiModel/BaseModel instances

**Incorrect positional argument to get_projection_quantiles**
- File: `flumodelingsuite/dispatcher/output.py:271`
- The code calls `get_projection_quantiles(outputs.quantiles.selections)` which passes the quantiles list as the first positional argument.
- However, the signature is `get_projection_quantiles(dates=None, quantiles=[...], ...)`, so the quantiles
list is incorrectly interpreted as dates, causing array length mismatches.
- Fix: Change to `get_projection_quantiles(quantiles=outputs.quantiles.selections)`

**NameError - undefined variable 'runner_output_calibration'**
- File: `flumodelingsuite/dispatcher/output.py:296`
- Line 296 uses `runner_output_calibration.results.get_projection_quantiles()` but the variable should be `calibration` to match the loop variable.
- Fix: Change `runner_output_calibration` to `calibration`

**NameError - undefined variable 'models'**
- File: `flumodelingsuite/dispatcher/output.py:433`
- Line 433 uses `for model in models:` but the variable is named `calibration` in the function signature.
- Fix: Change `for model in models:` to `for calibration in calibrations:` (Refactore function signature and registry keys from `calibration` to `calibrations`)

**Uninitialized variable 'quantiles_transitions'**
- File: `flumodelingsuite/dispatcher/output.py:468`
- When all projection quantiles fail to generate, `quantiles_transitions` is never initialized, but line 468 tries to check `if not quantiles_transitions.empty:`, causing UnboundLocalError.
- Fix: Initialize `quantiles_transitions = pd.DataFrame()` after `quantiles_compartments` initialization.

**to_csv with compression returns str instead of bytes**
- File: `flumodelingsuite/dispatcher/output.py:260-492` (all CSV output generation)
- When calling `to_csv(path_or_buf=None, compression="gzip")`, pandas returns uncompressed string instead of compressed bytes.
  - pandas to_csv with compression="gzip" and path_or_buf=None doesn't actually compress, just returns string with warning "compression has no effect when passing a non-binary object as input".
- Fix: Use BytesIO buffer. This can be inside a utility function `dataframe_to_gzipped_csv()`.
```py
buffer = io.BytesIO()
df.to_csv(buffer, compression="gzip")
data = buffer.getvalue()
```
- Without fix, CSV files have `.gz` extension but are not actually compressed. With fix, files are properly gzip-compressed.
