### PR TITLE
Vaccine allocation fix

### DIFF
--- a/epymodelingsuite/builders/orchestrators.py
+++ b/epymodelingsuite/builders/orchestrators.py
@@ -16,7 +16,7 @@ from ..schema.basemodel import BaseEpiModel, Parameter, Timespan
 from ..schema.calibration import CalibrationConfig, ComparisonSpec
 from ..school_closures import make_school_closure_dict
 from ..utils import get_location_codebook, make_dummy_population
-from ..vaccinations import reaggregate_vaccines, resample_dataframe, scenario_to_epydemix
+from ..vaccinations import reaggregate_vaccines, resample_vaccination_schedule, scenario_to_epydemix
 from .base import (
     add_model_compartments_from_config,
     add_model_parameters_from_config,
@@ -591,7 +591,7 @@ def apply_vaccination_for_sampled_start(
 
     # Start_date is sampled, need to reaggregate and resample
     reaggregated_vax = reaggregate_vaccines(earliest_vax, timespan.start_date)
-    reaggregated_resampled_vax = resample_dataframe(reaggregated_vax, timespan.delta_t)
+    reaggregated_resampled_vax = resample_vaccination_schedule(reaggregated_vax, timespan.delta_t)
     add_vaccination_schedules_from_config(
         model, basemodel.transitions, basemodel.vaccination, timespan, use_schedule=reaggregated_resampled_vax
     )

--- a/epymodelingsuite/builders/orchestrators.py
+++ b/epymodelingsuite/builders/orchestrators.py
@@ -157,7 +157,6 @@ def setup_vaccination_schedules(
             start_date=sampled_start_timespan.start_date,
             end_date=sampled_start_timespan.end_date,
             target_age_groups=basemodel.population.age_groups,
-            delta_t=sampled_start_timespan.delta_t,
             states=population_names,
         )
         return models, earliest_vax

--- a/epymodelingsuite/builders/vaccination.py
+++ b/epymodelingsuite/builders/vaccination.py
@@ -57,7 +57,6 @@ def add_vaccination_schedules_from_config(
                 start_date=timespan.start_date,
                 end_date=timespan.end_date,
                 target_age_groups=model.population.Nk_names,
-                delta_t=timespan.delta_t,
                 states=[model.population.name],
             )
             logger.info(f"Created vaccination schedule from scenario data at {vaccination.scenario_data_path}")

--- a/epymodelingsuite/vaccinations.py
+++ b/epymodelingsuite/vaccinations.py
@@ -126,7 +126,7 @@ def get_age_groups_from_data(data: pd.DataFrame) -> dict[str, str]:
     return age_group_map_data
 
 
-def resample_dataframe(df: pd.DataFrame, delta_t: float) -> pd.DataFrame:
+def resample_vaccination_schedule(df: pd.DataFrame, delta_t: float) -> pd.DataFrame:
     """
     Resample daily vaccination schedule to match simulation timesteps.
 

--- a/epymodelingsuite/vaccinations.py
+++ b/epymodelingsuite/vaccinations.py
@@ -128,33 +128,32 @@ def get_age_groups_from_data(data: pd.DataFrame) -> dict[str, str]:
 
 def resample_dataframe(df: pd.DataFrame, delta_t: float) -> pd.DataFrame:
     """
-    Resample a vaccination coverage DataFrame to match epydemix simulation time steps
-    by repeating values (step interpolation).
+    Resample daily vaccination schedule to match simulation timesteps.
 
-    This function preserves the step-wise nature of vaccination schedules,
-    where values should remain constant within each day/period rather than
-    being smoothly interpolated between periods.
-
-    Uses epydemix's compute_simulation_dates() to ensure exact alignment with simulation steps.
+    Adjusts the temporal resolution of a daily vaccination schedule to match the simulation's
+    delta_t by forward-filling values to maintain step-wise constant vaccination rates.
 
     Parameters
     ----------
     df : pd.DataFrame
-        Input DataFrame with at least the following columns:
-        - 'dates': datetime-like index column
-        - 'location': location identifier
-        - numeric coverage columns to be resampled
+        Daily vaccination schedule with 'dates' column, 'location' column, and numeric columns
+        for each age group containing daily vaccination counts.
     delta_t : float
-        Fraction of a day representing the new time step size. For example,
-        `delta_t=0.5` corresponds to 12-hour intervals, `delta_t=0.25` to 6-hour intervals.
+        Simulation time step in days. For example:
+        - delta_t=0.5: 12-hour intervals (values repeated twice per day)
+        - delta_t=1.0: daily intervals (no resampling, returns copy)
+        - delta_t=7.0: weekly intervals (aggregates 7 days into 1 timestep)
 
     Returns
     -------
     pd.DataFrame
-        Resampled DataFrame with:
-        - 'dates' as the new index column matching simulation time steps
-        - 'location' carried forward
-        - numeric columns repeated (not interpolated)
+        Vaccination schedule resampled to match simulation timesteps, with same columns as input.
+
+    Notes
+    -----
+    - Uses forward-fill (step interpolation) to preserve step-wise constant vaccination rates
+    - Does NOT multiply values by dt - values are repeated/aggregated as-is
+    - The vaccination rate function in epydemix handles dt conversion internally
     """
     import numpy as np
     from epydemix.utils import compute_simulation_dates
@@ -307,7 +306,6 @@ def scenario_to_epydemix(
     start_date: str | pd.Timestamp,
     end_date: str | pd.Timestamp,
     target_age_groups: list[str] = ["0-4", "5-17", "18-49", "50-64", "65+"],
-    delta_t: float = 1.0,
     output_filepath: str | None = None,
     states: list[str] | None = None,
 ) -> pd.DataFrame:
@@ -330,8 +328,6 @@ def scenario_to_epydemix(
         End date for the vaccination schedule (inclusive).
     target_age_groups : list of str, default ["0-4", "5-17", "18-49", "50-64", "65+"]
         Age groups to map the data to for the output schedule.
-    delta_t : float, default 1.0
-        Time step for resampling the daily vaccination data. Default 1.0 means daily.
     output_filepath : str, optional
         If provided, the processed daily vaccination DataFrame will be saved as a CSV at this path.
     states : list[str], optional
@@ -342,6 +338,7 @@ def scenario_to_epydemix(
     pd.DataFrame
         A DataFrame containing daily vaccination doses for each age group and location. Columns include:
         "dates", "location", and one column per target age group.
+        Returns daily vaccination schedules (dt=1.0).
 
     Raises
     ------
@@ -353,6 +350,7 @@ def scenario_to_epydemix(
     - The function aggregates weekly coverage into daily doses, distributes them evenly across days,
       and maps input age groups to the target model age groups using population reweighting.
     - Location names are converted to ISO codes for compatibility with Epydemix.
+    - Always returns daily schedules. Use resample_dataframe() to adjust temporal resolution for simulation timesteps.
     """
     import numpy as np
     from epydemix.utils import compute_simulation_dates
@@ -365,8 +363,8 @@ def scenario_to_epydemix(
         states = [convert_location_name_format(s, "name") for s in states]
 
     # ========== COMPUTE SIMULATION DATES ==========
-    # Use epydemix's date calculation to ensure alignment with simulation time steps
-    simulation_dates_array = compute_simulation_dates(start_date, end_date, dt=delta_t)
+    # Always generate daily schedules (dt=1.0)
+    simulation_dates_array = compute_simulation_dates(start_date, end_date, dt=1.0)
     simulation_dates_index = pd.DatetimeIndex(simulation_dates_array)
 
     # ========== LOAD AND FILTER DATA ==========
@@ -565,7 +563,6 @@ def smh_data_to_epydemix(
     start_date: str | pd.Timestamp,
     end_date: str | pd.Timestamp,
     target_age_groups: list[str] = ["0-4", "5-17", "18-49", "50-64", "65+"],
-    delta_t: float = 1.0,
     output_filepath: str | None = None,
     states: list[str] | None = None,
 ) -> pd.DataFrame:
@@ -582,7 +579,6 @@ def smh_data_to_epydemix(
         start_date (str or Timestamp): Start date of the simulation period.
         end_date (str or Timestamp): End date of the simulation period.
         target_age_groups (list[str]): Age groups to map the data to for the output schedule.
-        delta_t (float): Time step for resampling the daily vaccination data. Default 1.0 means daily.
         output_filepath (str, optional): If provided, the output DataFrame will be saved as a CSV.
         states (list[str], optional): If provided, only data for these specific states/locations will be processed.
 
@@ -590,6 +586,7 @@ def smh_data_to_epydemix(
     -------
         pd.DataFrame: DataFrame with columns ['dates', 'scenario', 'location', <age groups>] giving the
                       daily vaccination counts per age group for each scenario across all geographies.
+                      Returns daily vaccination schedules (dt=1.0).
     """
     import os
     import tempfile
@@ -639,7 +636,6 @@ def smh_data_to_epydemix(
                 start_date=start_date,
                 end_date=end_date,
                 target_age_groups=target_age_groups,
-                delta_t=delta_t,
                 output_filepath=None,  # Don't write individual scenario files
                 states=states,
             )

--- a/tests/builders/test_orchestrators.py
+++ b/tests/builders/test_orchestrators.py
@@ -634,7 +634,7 @@ class TestApplyVaccinationForSampledStart:
 
         with (
             patch("epymodelingsuite.builders.orchestrators.reaggregate_vaccines") as mock_reagg,
-            patch("epymodelingsuite.builders.orchestrators.resample_dataframe") as mock_resample,
+            patch("epymodelingsuite.builders.orchestrators.resample_vaccination_schedule") as mock_resample,
             patch("epymodelingsuite.builders.orchestrators.add_vaccination_schedules_from_config") as mock_add,
         ):
             mock_reagg.return_value = {"reaggregated": "data"}

--- a/tests/test_vaccinations.py
+++ b/tests/test_vaccinations.py
@@ -8,11 +8,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from epymodelingsuite.vaccinations import resample_dataframe, scenario_to_epydemix
+from epymodelingsuite.vaccinations import resample_vaccination_schedule, scenario_to_epydemix
 
 
 class TestResampleVaccinationSchedule:
-    """Tests for resample_dataframe function."""
+    """Tests for resample_vaccination_schedule function."""
 
     def test_forward_fill_subdaily(self):
         """Test forward-fill for dt < 1 without scaling."""
@@ -27,7 +27,7 @@ class TestResampleVaccinationSchedule:
         )
 
         # Resample to 12-hour timesteps (dt=0.5)
-        resampled = resample_dataframe(daily_schedule, delta_t=0.5)
+        resampled = resample_vaccination_schedule(daily_schedule, delta_t=0.5)
 
         # Values should be forward-filled (repeated), not scaled
         # Check that first day's values are repeated
@@ -48,7 +48,7 @@ class TestResampleVaccinationSchedule:
             }
         )
 
-        resampled = resample_dataframe(daily_schedule, delta_t=1.0)
+        resampled = resample_vaccination_schedule(daily_schedule, delta_t=1.0)
 
         # Should be identical to input
         assert len(resampled) == len(daily_schedule)
@@ -66,7 +66,7 @@ class TestResampleVaccinationSchedule:
         )
 
         # Resample to 12-hour timesteps
-        resampled = resample_dataframe(daily_schedule, delta_t=0.5)
+        resampled = resample_vaccination_schedule(daily_schedule, delta_t=0.5)
 
         # Verify structure is preserved
         assert "dates" in resampled.columns

--- a/tests/test_vaccinations.py
+++ b/tests/test_vaccinations.py
@@ -1,0 +1,115 @@
+"""Tests for vaccination data processing functions."""
+
+import os
+import tempfile
+from datetime import date
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from epymodelingsuite.vaccinations import resample_dataframe, scenario_to_epydemix
+
+
+class TestResampleVaccinationSchedule:
+    """Tests for resample_dataframe function."""
+
+    def test_forward_fill_subdaily(self):
+        """Test forward-fill for dt < 1 without scaling."""
+        # Create daily schedule with location column
+        daily_schedule = pd.DataFrame(
+            {
+                "dates": pd.date_range("2024-10-01", periods=3, freq="D"),
+                "location": ["US-MA", "US-MA", "US-MA"],
+                "0-4": [100.0, 200.0, 300.0],
+                "5-17": [150.0, 250.0, 350.0],
+            }
+        )
+
+        # Resample to 12-hour timesteps (dt=0.5)
+        resampled = resample_dataframe(daily_schedule, delta_t=0.5)
+
+        # Values should be forward-filled (repeated), not scaled
+        # Check that first day's values are repeated
+        assert resampled["0-4"].iloc[0] == 100.0
+        assert resampled["0-4"].iloc[1] == 100.0
+        # Check that second day's values are repeated
+        assert resampled["0-4"].iloc[2] == 200.0
+        assert resampled["0-4"].iloc[3] == 200.0
+
+    def test_no_resampling_when_daily(self):
+        """Test that dt=1.0 returns a copy without resampling."""
+        daily_schedule = pd.DataFrame(
+            {
+                "dates": pd.date_range("2024-10-01", periods=3, freq="D"),
+                "location": ["US-MA", "US-MA", "US-MA"],
+                "0-4": [100.0, 200.0, 300.0],
+                "5-17": [150.0, 250.0, 350.0],
+            }
+        )
+
+        resampled = resample_dataframe(daily_schedule, delta_t=1.0)
+
+        # Should be identical to input
+        assert len(resampled) == len(daily_schedule)
+        pd.testing.assert_frame_equal(resampled.reset_index(drop=True), daily_schedule)
+
+    def test_preserves_location_and_structure(self):
+        """Test that resampling preserves location and column structure."""
+        daily_schedule = pd.DataFrame(
+            {
+                "dates": pd.date_range("2024-10-01", periods=7, freq="D"),
+                "location": ["US-MA"] * 7,
+                "0-4": [100.0] * 7,
+                "5-17": [150.0] * 7,
+            }
+        )
+
+        # Resample to 12-hour timesteps
+        resampled = resample_dataframe(daily_schedule, delta_t=0.5)
+
+        # Verify structure is preserved
+        assert "dates" in resampled.columns
+        assert "location" in resampled.columns
+        assert "0-4" in resampled.columns
+        assert "5-17" in resampled.columns
+
+        # Verify location is preserved
+        assert all(resampled["location"] == "US-MA")
+
+
+class TestScenarioToEpydemix:
+    """Tests for scenario_to_epydemix function."""
+
+    def test_no_delta_t_parameter(self):
+        """Test that scenario_to_epydemix no longer accepts delta_t parameter."""
+        # Create a minimal temporary CSV file with properly formatted data
+        vaccination_data = pd.DataFrame(
+            {
+                "Week_Ending_Sat": ["2024-10-05", "2024-10-05", "2024-10-05"],
+                "Geography": ["California", "California", "California"],
+                "Age": ["6 Months - 4 Years", "5-17 Years", "6 Months - 17 Years"],
+                "Population": [500000, 1000000, 1500000],
+                "Coverage": [0.10, 0.15, 0.125],
+            }
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as temp_file:
+            vaccination_data.to_csv(temp_file.name, index=False)
+            temp_filepath = temp_file.name
+
+        try:
+            # This should raise TypeError if delta_t parameter is passed
+            with pytest.raises(TypeError, match="delta_t"):
+                scenario_to_epydemix(
+                    input_filepath=temp_filepath,
+                    start_date=date(2024, 10, 1),
+                    end_date=date(2024, 10, 7),
+                    target_age_groups=["0-4", "5-17", "18+"],
+                    delta_t=0.5,  # This should cause an error
+                )
+
+        finally:
+            # Clean up temporary file
+            if os.path.exists(temp_filepath):
+                os.unlink(temp_filepath)


### PR DESCRIPTION
Continued from https://github.com/mobs-lab/epymodelingsuite/pull/112. Resolves #122 .

## Changes
- `scenario_to_epydemix()`: Convert vaccine scenario to DAILY level schedules. It no longer takes dt as an argument.
- `reaggregate_vaccines()`: Reaggregate the schedule when start_date is sampled. This still returns DAILY level data. Will not take dt. (No change)
- `resample_vaccination_schedule()` previously `resample_dataframe()`: Resample dataframe for any dts. It takes dt as an argument. If dt<1, use forward fill.
- Add tests for vaccine allocation