### PR TITLE
Support non-preliminary data (dataset ID: ua7e-t2fy)

### DIFF
--- a/epymodelingsuite/utils/data.py
+++ b/epymodelingsuite/utils/data.py
@@ -10,6 +10,7 @@ from epymodelingsuite.utils.location import get_flusight_locations
 def fetch_hhs_hospitalizations(
     query_start_date: str | None = None,
     save_path: str | None = None,
+    data_type: str = "default",
 ) -> pd.DataFrame:
     """
     Fetch HHS flu hospitalization data from CDC's Socrata API.
@@ -23,6 +24,11 @@ def fetch_hhs_hospitalizations(
     save_path : str, optional
         Path to save the resulting CSV file.
         If provided, the DataFrame will be saved to this path before returning.
+    data_type : str, optional
+        Type of data to fetch. Options are:
+        - "default": Non-preliminary data (dataset ID: ua7e-t2fy)
+        - "preliminary": Preliminary data (dataset ID: mpgq-jmmr)
+        Default is "default".
 
     Returns
     -------
@@ -64,9 +70,12 @@ def fetch_hhs_hospitalizations(
     -----
     Data Source
         Weekly Hospital Respiratory Data (HRD) Metrics by Jurisdiction from CDC's
-        National Healthcare Safety Network (NHSN). See full documentation from the URL below.
-        URL: https://data.cdc.gov/Public-Health-Surveillance/Weekly-Hospital-Respiratory-Data-HRD-Metrics-by-Ju/mpgq-jmmr
-        Dataset ID: mpgq-jmmr.
+        National Healthcare Safety Network (NHSN). Two datasets are available:
+
+        - Default (non-preliminary): ua7e-t2fy
+          https://data.cdc.gov/Public-Health-Surveillance/Weekly-Hospital-Respiratory-Data-HRD-Metrics-by-Ju/ua7e-t2fy
+        - Preliminary: mpgq-jmmr
+          https://data.cdc.gov/Public-Health-Surveillance/Weekly-Hospital-Respiratory-Data-HRD-Metrics-by-Ju/mpgq-jmmr
 
     Data Field
         Uses `totalconfflunewadm`: total number of new hospital admissions of patients
@@ -77,15 +86,27 @@ def fetch_hhs_hospitalizations(
         aggregates. Territories (AS, GU, MP, PR, VI) and HHS regions are excluded from the output.
 
     """
+    # Map data_type to dataset IDs
+    dataset_ids = {
+        "default": "ua7e-t2fy",  # Non-preliminary data
+        "preliminary": "mpgq-jmmr",  # Preliminary data
+    }
+
+    if data_type not in dataset_ids:
+        msg = f"Invalid data_type: {data_type}. Must be 'default' or 'preliminary'"
+        raise ValueError(msg)
+
+    dataset_id = dataset_ids[data_type]
+
     # Initialize Socrata client
     client = Socrata("data.cdc.gov", None)
 
     # Build query
     if query_start_date:
         where_clause = f"weekendingdate >= '{query_start_date}'"
-        results = client.get("mpgq-jmmr", where=where_clause, limit=100000)
+        results = client.get(dataset_id, where=where_clause, limit=100000)
     else:
-        results = client.get("mpgq-jmmr", limit=100000)
+        results = client.get(dataset_id, limit=100000)
 
     # Convert to pandas DataFrame
     data = pd.DataFrame.from_records(results)

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -85,8 +85,8 @@ class TestFetchHHSHospitalizations:
         # Verify Socrata client initialization
         mock_socrata_class.assert_called_once_with("data.cdc.gov", None)
 
-        # Verify get was called without where clause
-        mock_client.get.assert_called_once_with("mpgq-jmmr", limit=100000)
+        # Verify get was called without where clause (default uses ua7e-t2fy)
+        mock_client.get.assert_called_once_with("ua7e-t2fy", limit=100000)
 
         # Verify result structure
         assert isinstance(result, pd.DataFrame)
@@ -138,9 +138,9 @@ class TestFetchHHSHospitalizations:
         # Call function with date filter
         result = fetch_hhs_hospitalizations(query_start_date="2024-10-01")
 
-        # Verify get was called with where clause
+        # Verify get was called with where clause (default uses ua7e-t2fy)
         mock_client.get.assert_called_once_with(
-            "mpgq-jmmr",
+            "ua7e-t2fy",
             where="weekendingdate >= '2024-10-01'",
             limit=100000,
         )
@@ -288,3 +288,64 @@ class TestFetchHHSHospitalizations:
         tx_data = result[result["location_code"] == "48"]
         tx_dates = tx_data["target_end_date"].tolist()
         assert tx_dates[0] < tx_dates[1], "TX dates should be in ascending order"
+
+    @patch("epymodelingsuite.utils.data.Socrata")
+    @patch("epymodelingsuite.utils.data.get_flusight_locations")
+    def test_data_type_default(self, mock_get_locations, mock_socrata_class, mock_socrata_data, mock_locations_data):
+        """Test that default data_type uses non-preliminary dataset."""
+        # Setup mocks
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_socrata_data
+        mock_socrata_class.return_value = mock_client
+        mock_get_locations.return_value = mock_locations_data
+
+        # Call function with explicit default data_type
+        fetch_hhs_hospitalizations(data_type="default")
+
+        # Verify non-preliminary dataset ID is used
+        mock_client.get.assert_called_once_with("ua7e-t2fy", limit=100000)
+
+    @patch("epymodelingsuite.utils.data.Socrata")
+    @patch("epymodelingsuite.utils.data.get_flusight_locations")
+    def test_data_type_preliminary(
+        self, mock_get_locations, mock_socrata_class, mock_socrata_data, mock_locations_data
+    ):
+        """Test that preliminary data_type uses preliminary dataset."""
+        # Setup mocks
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_socrata_data
+        mock_socrata_class.return_value = mock_client
+        mock_get_locations.return_value = mock_locations_data
+
+        # Call function with preliminary data_type
+        fetch_hhs_hospitalizations(data_type="preliminary")
+
+        # Verify preliminary dataset ID is used
+        mock_client.get.assert_called_once_with("mpgq-jmmr", limit=100000)
+
+    @patch("epymodelingsuite.utils.data.Socrata")
+    @patch("epymodelingsuite.utils.data.get_flusight_locations")
+    def test_data_type_preliminary_with_date_filter(
+        self, mock_get_locations, mock_socrata_class, mock_socrata_data, mock_locations_data
+    ):
+        """Test preliminary data_type with date filter."""
+        # Setup mocks
+        mock_client = MagicMock()
+        mock_client.get.return_value = mock_socrata_data
+        mock_socrata_class.return_value = mock_client
+        mock_get_locations.return_value = mock_locations_data
+
+        # Call function with date filter and preliminary data_type
+        fetch_hhs_hospitalizations(query_start_date="2024-10-01", data_type="preliminary")
+
+        # Verify preliminary dataset ID is used with where clause
+        mock_client.get.assert_called_once_with(
+            "mpgq-jmmr",
+            where="weekendingdate >= '2024-10-01'",
+            limit=100000,
+        )
+
+    def test_invalid_data_type(self):
+        """Test that invalid data_type raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid data_type"):
+            fetch_hhs_hospitalizations(data_type="invalid")


### PR DESCRIPTION
Resolves #147.

## Changes made
- Added `data_type` argument to `fetch_hhs_hospitalizations()`
- By default, it fetches data from [non-preliminary repository](https://data.cdc.gov/Public-Health-Surveillance/Weekly-Hospital-Respiratory-Data-HRD-Metrics-by-Ju/ua7e-t2fy/about_data). When `data_type="preliminary"`, it fetches from [preliminary repository](https://data.cdc.gov/Public-Health-Surveillance/Weekly-Hospital-Respiratory-Data-HRD-Metrics-by-Ju/mpgq-jmmr/about_data).
- Confirmed that the data processing works for both data sources. (The data format and structure are same).