### PR TITLE
Add extract_builder_metadata to `__all__` exports

### DIFF
--- a/epymodelingsuite/telemetry/__init__.py
+++ b/epymodelingsuite/telemetry/__init__.py
@@ -9,4 +9,5 @@ from .extractors import extract_builder_metadata
 __all__ = [
     "ExecutionTelemetry",
     "create_workflow_telemetry",
+    "extract_builder_metadata",
 ]


### PR DESCRIPTION
Missing import of `extract_builder_metadata`. Added to `__all__`.