### PR TITLE
Output config reorganization / plotting updates

### DIFF
--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -976,11 +976,23 @@ def generate_calibration_outputs(
             hub_format_output_list.append(quanf_df)
 
         # Rate-trend forecasts
-        if output.flusight_format.rate_trends:
+        if output.flusight_format.rate_trends_source:
+            # Get surveillance source configuration
+            if not output.options or not output.options.surveillance:
+                msg = "rate_trends_source specified but no surveillance sources defined in output.options.surveillance"
+                raise ValueError(msg)
+
+            source_name = output.flusight_format.rate_trends_source
+            if source_name not in output.options.surveillance:
+                msg = f"rate_trends_source '{source_name}' not found in output.options.surveillance"
+                raise ValueError(msg)
+
+            source_config = output.options.surveillance[source_name]
+
             # Read surveillance data
             surveillance = pd.read_csv(
-                output.flusight_format.rate_trends.data_path,
-                parse_dates=["target_end_date"],
+                source_config.data_path,
+                parse_dates=[source_config.date_column],
                 date_format="%Y-%m-%d",
             )
 
@@ -996,13 +1008,13 @@ def generate_calibration_outputs(
 
                 # Filter surveillance for location
                 surv = surveillance[
-                    surveillance[output.flusight_format.rate_trends.location_column]
+                    surveillance[source_config.location_column]
                     == convert_location_name_format(calibration.population, "ISO")
                 ]
-                surv = surv.drop(columns=output.flusight_format.rate_trends.location_column).rename(
+                surv = surv.drop(columns=source_config.location_column).rename(
                     columns={
-                        output.flusight_format.rate_trends.date_column: "date",
-                        output.flusight_format.rate_trends.value_column: "value",
+                        source_config.date_column: "date",
+                        source_config.value_column: "value",
                     }
                 )
 
@@ -1020,6 +1032,24 @@ def generate_calibration_outputs(
                 trends_df.insert(0, "reference_date", output.flusight_format.reference_date)
                 trends_df.insert(0, "location", convert_location_name_format(calibration.population, "FIPS"))
                 hub_format_output_list.append(trends_df)
+
+        # Prop ED visits forecasts
+        if output.flusight_format.prop_ed_source:
+            # Get surveillance source configuration
+            if not output.options or not output.options.surveillance:
+                msg = "prop_ed_source specified but no surveillance sources defined in output.options.surveillance"
+                raise ValueError(msg)
+
+            source_name = output.flusight_format.prop_ed_source
+            if source_name not in output.options.surveillance:
+                msg = f"prop_ed_source '{source_name}' not found in output.options.surveillance"
+                raise ValueError(msg)
+
+            # TODO: Implement prop_ed forecast generation when make_prop_ed_flusightforecast() is implemented
+            # source_config = output.options.surveillance[source_name]
+            # surveillance = pd.read_csv(source_config.data_path, ...)
+            # ... prop_ed generation logic ...
+            logger.warning("prop_ed_source specified but prop_ed forecast generation is not yet implemented")
 
         hub_format_output = (
             pd.concat(hub_format_output_list, ignore_index=True) if hub_format_output_list else pd.DataFrame()

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -527,6 +527,7 @@ def generate_simulation_outputs(
 
     ### Quantiles
     if output.quantiles:
+        logger.info("Generating quantile outputs")
         for simulation in simulations:
             # Compartments
             if output.quantiles.compartments:
@@ -571,6 +572,7 @@ def generate_simulation_outputs(
 
     ### Trajectories
     if output.trajectories:
+        logger.info("Generating trajectory outputs")
         for simulation in simulations:
             for i, traj in enumerate(simulation.results.trajectories):
                 # Compartments
@@ -626,6 +628,7 @@ def generate_simulation_outputs(
 
     ### Model Metadata
     if output.model_meta:
+        logger.info("Generating model metadata outputs")
         if output.model_meta.projection_parameters:
             warnings.add("OUTPUT_GENERATOR: Requested projection parameter metadata in simulation workflow, ignoring.")
 
@@ -655,6 +658,7 @@ def generate_simulation_outputs(
     for warning in warnings:
         logger.warning(warning)
 
+    logger.info("Formatting tabular outputs")
     out_dict = {}
     if not quantiles_compartments.empty:
         qc_name = "quantiles_compartments"
@@ -690,6 +694,7 @@ def generate_simulation_outputs(
         mm_objects = [format_tabular_object(model_meta, mm_name, _type) for _type in output.tabular_output_types]
         out_dict[mm_name] = mm_objects
 
+    logger.info("Output generation complete. Generated %d output types", len(out_dict))
     logger.info("OUTPUT GENERATOR: completed for simulation")
 
     return out_dict
@@ -727,6 +732,7 @@ def generate_calibration_outputs(
 
     ### Quantiles
     if output.quantiles:
+        logger.info("Generating quantile outputs")
         for calibration in calibrations:  # Calibration quantiles (only for calibration comparison target)
             # Calibration quantiles
             if output.quantiles.calibration:
@@ -841,6 +847,7 @@ def generate_calibration_outputs(
 
     ### Trajectories
     if output.trajectories:
+        logger.info("Generating trajectory outputs")
         for calibration in calibrations:
             # Filter out failed projections
             calibration.results = filter_failed_projections(calibration.results)
@@ -928,6 +935,7 @@ def generate_calibration_outputs(
 
     ### Posteriors
     if output.posteriors:
+        logger.info("Generating posterior outputs")
         for calibration in calibrations:
             # Output last generation (default)
             if output.posteriors == True:
@@ -958,7 +966,9 @@ def generate_calibration_outputs(
 
     # FluSight Forecast Hub
     if output.flusight_format:
+        logger.info("Generating FluSight forecast hub outputs")
         # Quantile forecasts
+        logger.info("  - Generating FluSight quantile forecasts")
         for calibration in calibrations:
             try:
                 # FRAGILE: the name 'hospitalizations' is user-supplied in the modelset as the column to look for in the surveillance data.
@@ -977,6 +987,7 @@ def generate_calibration_outputs(
 
         # Rate-trend forecasts
         if output.flusight_format.rate_trends_source:
+            logger.info("  - Generating FluSight rate-trend forecasts")
             # Get surveillance source configuration
             if not output.options or not output.options.surveillance:
                 msg = "rate_trends_source specified but no surveillance sources defined in output.options.surveillance"
@@ -1061,6 +1072,7 @@ def generate_calibration_outputs(
 
     ### Model Metadata
     if output.model_meta:
+        logger.info("Generating model metadata outputs")
         meta_dict = defaultdict(list)
         for calibration in calibrations:
             meta_dict["primary_id"].append(calibration.primary_id)
@@ -1115,6 +1127,7 @@ def generate_calibration_outputs(
     for warning in warnings:
         logger.warning(warning)
 
+    logger.info("Formatting tabular outputs")
     out_dict = {}
     if not quantiles_projection_compartments.empty:
         qc_name = "quantiles_projection_compartments"
@@ -1176,11 +1189,14 @@ def generate_calibration_outputs(
                 start_date_reference = str(calibration.start_date_reference)
                 break
 
+        logger.info("  - Generating quantile plots")
         generate_single_quantile_plots(calibrations, plots_config, out_dict)
         generate_quantile_grid_plot(calibrations, plots_config, out_dict)
+        logger.info("  - Generating posterior plots")
         generate_single_location_posterior_plots(calibrations, plots_config, out_dict, start_date_reference)
         generate_posterior_grid_plot(calibrations, plots_config, out_dict, start_date_reference)
 
+    logger.info("Output generation complete. Generated %d output types", len(out_dict))
     return out_dict
 
 

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -1190,8 +1190,13 @@ def generate_calibration_outputs(
                 break
 
         logger.info("  - Generating quantile plots")
-        generate_single_quantile_plots(calibrations, plots_config, out_dict)
-        generate_quantile_grid_plot(calibrations, plots_config, out_dict)
+        # Extract surveillance sources from output config if available
+        surveillance_sources = None
+        if output.options and output.options.surveillance:
+            surveillance_sources = output.options.surveillance
+
+        generate_single_quantile_plots(calibrations, plots_config, out_dict, surveillance_sources)
+        generate_quantile_grid_plot(calibrations, plots_config, out_dict, surveillance_sources)
         logger.info("  - Generating posterior plots")
         generate_single_location_posterior_plots(calibrations, plots_config, out_dict, start_date_reference)
         generate_posterior_grid_plot(calibrations, plots_config, out_dict, start_date_reference)

--- a/epymodelingsuite/schema/general.py
+++ b/epymodelingsuite/schema/general.py
@@ -235,19 +235,32 @@ def _warn_mismatched_observed_data_paths(
         return
 
     output = output_config.output
-    if output.flusight_format is None or output.flusight_format.rate_trends is None:
+    if output.flusight_format is None or output.flusight_format.rate_trends_source is None:
+        return
+
+    # Get surveillance source configuration
+    if not output.options or not output.options.surveillance:
+        logger.warning(
+            "FluSight rate_trends_source specified but no surveillance sources defined in output.options.surveillance"
+        )
+        return
+
+    source_name = output.flusight_format.rate_trends_source
+    if source_name not in output.options.surveillance:
+        logger.warning("FluSight rate_trends_source '%s' not found in output.options.surveillance", source_name)
         return
 
     calibration_path = calibration.observed_data_path
-    output_path = output.flusight_format.rate_trends.observed_data_path
+    output_path = output.options.surveillance[source_name].data_path
 
     if calibration_path != output_path:
         logger.warning(
             "Observed data paths differ between configs: "
             "calibration='%s', "
-            "output.flusight_format.rate_trends='%s'. "
+            "output.flusight_format.rate_trends_source ('%s')='%s'. "
             "This may lead to inconsistent results if the files contain different data.",
             calibration_path,
+            source_name,
             output_path,
         )
 

--- a/epymodelingsuite/schema/output.py
+++ b/epymodelingsuite/schema/output.py
@@ -169,6 +169,38 @@ class PosteriorPlotConfig(BaseModel):
     bins: int = Field(30, description="Number of histogram bins.")
 
 
+class QuantilesOutputTypeEnum(str, Enum):
+    """Types of quantile plot outputs."""
+
+    FILTERED = "filtered"
+    FULL = "full"
+    SIDE_BY_SIDE = "side_by_side"
+
+
+class QuantilesOutputConfig(BaseModel):
+    """Configuration for a single quantile plot output."""
+
+    type: QuantilesOutputTypeEnum = Field(description="Type of output to generate.")
+
+    # Display options (for all output types)
+    show_calibration: bool = Field(False, description="Show calibration period quantiles.")
+    show_projection: bool = Field(True, description="Show projection period quantiles.")
+    show_surveillance: bool = Field(True, description="Overlay surveillance observations.")
+    show_fitting_window_line: bool = Field(True, description="Show fitting window vertical lines.")
+
+    # Filter settings (only for FILTERED and FULL types)
+    # IGNORED for SIDE_BY_SIDE type (uses hardcoded filters)
+    surveillance_points: int | None = Field(
+        None, description="Number of most recent surveillance points to display. None = all points."
+    )
+    horizon_max: int | None = Field(None, description="Override base horizon_max. None = use base config value.")
+
+    # Layout settings (only for SIDE_BY_SIDE type)
+    columns: int = Field(4, description="For grid side-by-side: number of subplot columns (2 location-pairs per row).")
+    spacing: float = Field(0.3, description="For side-by-side: horizontal spacing between panels.")
+    figsize: tuple[float, float] | None = Field(None, description="For side-by-side: figure size (width, height).")
+
+
 class QuantilesGridConfig(BaseModel):
     """Configuration for quantiles grid plot."""
 
@@ -177,36 +209,24 @@ class QuantilesGridConfig(BaseModel):
 
 
 class QuantilesCalibrationConfig(BaseModel):
-    """Configuration for calibration period visualization."""
+    """Configuration for calibration period visualization styling."""
 
-    show: bool = Field(True, description="Show calibration period quantiles.")
     color: str = Field("C0", description="Color for calibration ribbons.")
 
 
 class QuantilesProjectionConfig(BaseModel):
-    """Configuration for projection period visualization."""
+    """Configuration for projection period visualization styling."""
 
-    show: bool = Field(True, description="Show projection period quantiles.")
     color: str = Field("C1", description="Color for projection ribbons.")
 
 
 class QuantilesSurveillanceConfig(BaseModel):
-    """Configuration for surveillance data overlay."""
+    """Configuration for surveillance data source."""
 
-    show: bool = Field(True, description="Overlay surveillance observations.")
     data_path: str | None = Field(None, description="Path to surveillance data file.")
     value_column: str | None = Field(None, description="Column containing observed values.")
     date_column: str | None = Field(None, description="Column containing dates.")
     location_column: str | None = Field(None, description="Column containing location identifiers.")
-    surveillance_points: int | None = Field(
-        8, description="Number of most recent surveillance points to display. If None, show all points."
-    )
-
-
-class QuantilesFittingWindowLineConfig(BaseModel):
-    """Configuration for fitting window end vertical line."""
-
-    show: bool = Field(True, description="Show vertical line at end of calibration/fitting window.")
 
 
 class QuantilesPlotConfig(BaseModel):
@@ -220,29 +240,60 @@ class QuantilesPlotConfig(BaseModel):
         default_factory=QuantilesGridConfig,
         description="Grid plot configuration.",
     )
+
+    # Output configuration
+    outputs: list[QuantilesOutputConfig] = Field(
+        default_factory=lambda: [
+            QuantilesOutputConfig(
+                type=QuantilesOutputTypeEnum.FILTERED,
+                surveillance_points=8,
+                show_calibration=False,
+                show_projection=True,
+                show_surveillance=True,
+                show_fitting_window_line=True,
+            ),
+            QuantilesOutputConfig(
+                type=QuantilesOutputTypeEnum.FULL,
+                surveillance_points=None,
+                show_calibration=False,
+                show_projection=True,
+                show_surveillance=True,
+                show_fitting_window_line=True,
+            ),
+            QuantilesOutputConfig(
+                type=QuantilesOutputTypeEnum.SIDE_BY_SIDE,
+                show_calibration=False,
+                show_projection=True,
+                show_surveillance=True,
+                show_fitting_window_line=True,
+                columns=4,
+                spacing=0.3,
+            ),
+        ],
+        description="List of output configurations to generate.",
+    )
+
+    # Shared settings
     quantiles: list[float] = Field(
         [0.025, 0.25, 0.5, 0.75, 0.975],
         description="Quantile levels for ribbons (95% CrI + IQR + median).",
     )
     horizon_max: int | None = Field(
-        3, description="Maximum forecast horizon (weeks ahead) to display. If None, show all horizons."
+        3, description="Base maximum forecast horizon (weeks ahead). Can be overridden per output."
     )
 
+    # Shared styling (data source and colors)
     calibration: QuantilesCalibrationConfig = Field(
         default_factory=QuantilesCalibrationConfig,
-        description="Calibration period settings.",
+        description="Calibration period styling.",
     )
     projection: QuantilesProjectionConfig = Field(
         default_factory=QuantilesProjectionConfig,
-        description="Projection period settings.",
+        description="Projection period styling.",
     )
     surveillance: QuantilesSurveillanceConfig = Field(
-        default_factory=QuantilesSurveillanceConfig,
-        description="Surveillance data overlay settings.",
-    )
-    fitting_window_line: QuantilesFittingWindowLineConfig = Field(
-        default_factory=QuantilesFittingWindowLineConfig,
-        description="Fitting window end line settings.",
+        ...,
+        description="Surveillance data source configuration.",
     )
 
     @field_validator("quantiles")
@@ -308,6 +359,7 @@ class OutputConfiguration(BaseModel):
         default_factory=ModelMetaOutput, description="Specifications for parameter tracking / model metadata outputs."
     )
 
+    # Plots
     plots: PlotsConfig | None = Field(
         None,
         description="Visualization plot settings. Requires modelset config for inference.",

--- a/epymodelingsuite/schema/output.py
+++ b/epymodelingsuite/schema/output.py
@@ -177,6 +177,17 @@ class QuantilesOutputTypeEnum(str, Enum):
     SIDE_BY_SIDE = "side_by_side"
 
 
+class SideBySidePanelConfig(BaseModel):
+    """Configuration for a single panel in side-by-side plot."""
+
+    surveillance_points: int | None = Field(
+        None, description="Number of most recent surveillance points to display. None = all points."
+    )
+    surveillance_start_date: str | None = Field(
+        None, description="Filter surveillance to show only points >= this date (YYYY-MM-DD). Overrides surveillance_points if both set."
+    )
+
+
 class QuantilesOutputConfig(BaseModel):
     """Configuration for a single quantile plot output."""
 
@@ -189,14 +200,23 @@ class QuantilesOutputConfig(BaseModel):
     show_fitting_window_line: bool = Field(True, description="Show fitting window vertical lines.")
 
     # Filter settings (only for FILTERED and FULL types)
-    # IGNORED for SIDE_BY_SIDE type (uses hardcoded filters)
     surveillance_points: int | None = Field(
-        None, description="Number of most recent surveillance points to display. None = all points."
+        None, description="Number of most recent surveillance points to display. None = all points. Not used for SIDE_BY_SIDE."
+    )
+    surveillance_start_date: str | None = Field(
+        None, description="Filter surveillance to show only points >= this date (YYYY-MM-DD). Overrides surveillance_points if both set. Not used for SIDE_BY_SIDE."
     )
     horizon_max: int | None = Field(None, description="Override base horizon_max. None = use base config value.")
 
+    # Panel settings (only for SIDE_BY_SIDE type)
+    full_panel: SideBySidePanelConfig | None = Field(
+        None, description="Configuration for full (left) panel in side-by-side plot."
+    )
+    filtered_panel: SideBySidePanelConfig | None = Field(
+        None, description="Configuration for filtered (right) panel in side-by-side plot."
+    )
+
     # Layout settings (only for SIDE_BY_SIDE type)
-    columns: int = Field(4, description="For grid side-by-side: number of subplot columns (2 location-pairs per row).")
     spacing: float = Field(0.3, description="For side-by-side: horizontal spacing between panels.")
     figsize: tuple[float, float] | None = Field(None, description="For side-by-side: figure size (width, height).")
 

--- a/epymodelingsuite/schema/output.py
+++ b/epymodelingsuite/schema/output.py
@@ -92,24 +92,19 @@ class ObservedValuesConfig(BaseModel):
     location_column: str = Field(description="Name of column containing location in observed data CSV")
 
 
-class FlusightRateTrends(BaseModel):
-    """Specifications for FluSight rate-trends."""
-
-    observed_data_path: str = Field(description="Path to observed data CSV file")
-    observed_value_column: str = Field(description="Name of column containing observed values in observed data CSV")
-    observed_date_column: str = Field(description="Name of column containing target dates in observed data CSV")
-    observed_location_column: str = Field(description="Name of column containing location in observed data CSV")
-
-
 class FlusightForecastOutput(BaseModel):
     """Specifications for outputs in flusight forecast hub format."""
 
     reference_date: date = Field(
         description="'YYYY-MM-DD' date to treat as reference date when creating horizons and target dates for submission file."
     )
-    rate_trends: FlusightRateTrends | None = Field(
+    rate_trends_source: str | None = Field(
         None,
-        description="Add rate-trend forecasts to submission file.",
+        description="Name of surveillance source from output.options.surveillance to use for rate-trend forecasts.",
+    )
+    prop_ed_source: str | None = Field(
+        None,
+        description="Name of surveillance source from output.options.surveillance to use for proportion ED visits forecasts.",
     )
 
 
@@ -449,6 +444,78 @@ class OutputConfiguration(BaseModel):
 
         if len([1 for _ in hub_formats if bool(_)]) > 1:
             raise ValueError("Received specifications for more than one hub format.")
+
+        return self
+
+    @model_validator(mode="after")
+    def validate_surveillance_references(self):
+        """Ensure all surveillance_source references point to valid sources."""
+        # If no surveillance sources defined, check if any are referenced
+        if not self.options or not self.options.surveillance:
+            errors = []
+
+            # Check flusight_format
+            if self.flusight_format:
+                if self.flusight_format.rate_trends_source:
+                    errors.append(
+                        f"flusight_format.rate_trends_source='{self.flusight_format.rate_trends_source}' "
+                        "but no surveillance sources defined in output.options.surveillance"
+                    )
+                if self.flusight_format.prop_ed_source:
+                    errors.append(
+                        f"flusight_format.prop_ed_source='{self.flusight_format.prop_ed_source}' "
+                        "but no surveillance sources defined in output.options.surveillance"
+                    )
+
+            # Check plots.quantiles.outputs
+            if self.plots and self.plots.quantiles:
+                for i, output in enumerate(self.plots.quantiles.outputs):
+                    if output.surveillance_source:
+                        errors.append(
+                            f"plots.quantiles.outputs[{i}].surveillance_source='{output.surveillance_source}' "
+                            "but no surveillance sources defined in output.options.surveillance"
+                        )
+
+            if errors:
+                msg = "Surveillance source references without defined sources:\n" + "\n".join(
+                    f"  - {e}" for e in errors
+                )
+                raise ValueError(msg)
+
+            return self
+
+        # Surveillance sources defined - validate references exist
+        available_sources = set(self.options.surveillance.keys())
+        errors = []
+
+        # Check flusight_format
+        if self.flusight_format:
+            if (
+                self.flusight_format.rate_trends_source
+                and self.flusight_format.rate_trends_source not in available_sources
+            ):
+                errors.append(
+                    f"flusight_format.rate_trends_source='{self.flusight_format.rate_trends_source}' "
+                    f"not found in surveillance sources: {available_sources}"
+                )
+            if self.flusight_format.prop_ed_source and self.flusight_format.prop_ed_source not in available_sources:
+                errors.append(
+                    f"flusight_format.prop_ed_source='{self.flusight_format.prop_ed_source}' "
+                    f"not found in surveillance sources: {available_sources}"
+                )
+
+        # Check plots.quantiles.outputs
+        if self.plots and self.plots.quantiles:
+            for i, output in enumerate(self.plots.quantiles.outputs):
+                if output.surveillance_source and output.surveillance_source not in available_sources:
+                    errors.append(
+                        f"plots.quantiles.outputs[{i}].surveillance_source='{output.surveillance_source}' "
+                        f"not found in surveillance sources: {available_sources}"
+                    )
+
+        if errors:
+            msg = "Invalid surveillance source references:\n" + "\n".join(f"  - {e}" for e in errors)
+            raise ValueError(msg)
 
         return self
 

--- a/epymodelingsuite/visualization/core.py
+++ b/epymodelingsuite/visualization/core.py
@@ -500,6 +500,145 @@ def plot_calibration_projection(  # noqa: PLR0913
     return fig, ax
 
 
+def plot_calibration_projection_sidebyside(  # noqa: PLR0913
+    calibration_quantiles: pd.DataFrame | None = None,
+    projection_quantiles_full: pd.DataFrame | None = None,
+    projection_quantiles_filtered: pd.DataFrame | None = None,
+    surveillance_full: pd.DataFrame | None = None,
+    surveillance_filtered: pd.DataFrame | None = None,
+    value_col: str = "hospitalizations",
+    date_col: str = "date",
+    quantile_col: str = "quantile",
+    calibration_color: str = "C0",
+    projection_color: str = "C1",
+    surveillance_date_col: str = "date",
+    surveillance_value_col: str = "value",
+    surveillance_size: float = 30.0,
+    fitting_window_start: str | pd.Timestamp | datetime | None = None,
+    fitting_window_end: str | pd.Timestamp | datetime | None = None,
+    title: str | None = None,
+    figsize: tuple[float, float] | None = None,
+    spacing: float = 0.3,
+) -> tuple[plt.Figure, tuple[plt.Axes, plt.Axes]]:
+    """
+    Create side-by-side quantile plots: [Full Range | Filtered].
+
+    Left panel shows full surveillance range with projection filtered only by horizon_max.
+    Right panel shows limited surveillance points with projection filtered by both
+    surveillance start and horizon_max.
+
+    Parameters
+    ----------
+    calibration_quantiles : pd.DataFrame | None, optional
+        Pre-computed quantiles for calibration period (shown in both panels).
+    projection_quantiles_full : pd.DataFrame | None, optional
+        Projection quantiles for left panel (full range, horizon_max only).
+    projection_quantiles_filtered : pd.DataFrame | None, optional
+        Projection quantiles for right panel (filtered by surveillance + horizon).
+    surveillance_full : pd.DataFrame | None, optional
+        Full surveillance data for left panel.
+    surveillance_filtered : pd.DataFrame | None, optional
+        Filtered surveillance data for right panel.
+    value_col : str, optional
+        Name of column containing values to plot, by default "hospitalizations".
+    date_col : str, optional
+        Name of date column, by default "date".
+    quantile_col : str, optional
+        Name of quantile column, by default "quantile".
+    calibration_color : str, optional
+        Color for calibration ribbons, by default "C0".
+    projection_color : str, optional
+        Color for projection ribbons, by default "C1".
+    surveillance_date_col : str, optional
+        Date column in surveillance data, by default "date".
+    surveillance_value_col : str, optional
+        Value column in surveillance data, by default "value".
+    surveillance_size : float, optional
+        Marker size for surveillance points, by default 30.0.
+    fitting_window_start : str | pd.Timestamp | datetime | None, optional
+        If provided, draw vertical line at start of calibration/fitting window,
+        by default None.
+    fitting_window_end : str | pd.Timestamp | datetime | None, optional
+        If provided, draw vertical line at end of calibration/fitting window,
+        by default None.
+    title : str | None, optional
+        Base plot title (will be suffixed with panel type), by default None.
+    figsize : tuple[float, float] | None, optional
+        Figure size. If None, defaults to (16, 6).
+    spacing : float, optional
+        Horizontal spacing between subplots, by default 0.3.
+
+    Returns
+    -------
+    tuple[plt.Figure, tuple[plt.Axes, plt.Axes]]
+        Figure and tuple of (ax_full, ax_filtered) axes objects.
+
+    Examples
+    --------
+    >>> # Prepare data with two versions
+    >>> cal_quant = results.get_calibration_quantiles([0.025, 0.5, 0.975])
+    >>> proj_quant_full = results.get_projection_quantiles([0.025, 0.5, 0.975])
+    >>> # Filter projection for right panel
+    >>> proj_quant_filtered = proj_quant_full[proj_quant_full["date"] >= surveillance_start]
+    >>> fig, (ax_full, ax_filtered) = plot_calibration_projection_sidebyside(
+    ...     calibration_quantiles=cal_quant,
+    ...     projection_quantiles_full=proj_quant_full,
+    ...     projection_quantiles_filtered=proj_quant_filtered,
+    ...     surveillance_full=surv_full,
+    ...     surveillance_filtered=surv_filtered,
+    ...     value_col="hospitalizations",
+    ...     title="US-CA"
+    ... )
+    >>> fig.savefig("sidebyside_forecast.png")
+    >>> plt.close(fig)
+
+    """
+    if figsize is None:
+        figsize = (16, 6)
+
+    fig, (ax_full, ax_filtered) = plt.subplots(1, 2, figsize=figsize, gridspec_kw={"wspace": spacing})
+
+    # Left panel: Full range
+    plot_calibration_projection(
+        calibration_quantiles=calibration_quantiles,
+        projection_quantiles=projection_quantiles_full,
+        value_col=value_col,
+        date_col=date_col,
+        quantile_col=quantile_col,
+        calibration_color=calibration_color,
+        projection_color=projection_color,
+        df_surveillance=surveillance_full,
+        surveillance_date_col=surveillance_date_col,
+        surveillance_value_col=surveillance_value_col,
+        surveillance_size=surveillance_size,
+        fitting_window_start=fitting_window_start,
+        fitting_window_end=fitting_window_end,
+        title=f"{title} - Full Range" if title else "Full Range",
+        ax=ax_full,
+    )
+
+    # Right panel: Filtered
+    plot_calibration_projection(
+        calibration_quantiles=calibration_quantiles,
+        projection_quantiles=projection_quantiles_filtered,
+        value_col=value_col,
+        date_col=date_col,
+        quantile_col=quantile_col,
+        calibration_color=calibration_color,
+        projection_color=projection_color,
+        df_surveillance=surveillance_filtered,
+        surveillance_date_col=surveillance_date_col,
+        surveillance_value_col=surveillance_value_col,
+        surveillance_size=surveillance_size,
+        fitting_window_start=fitting_window_start,
+        fitting_window_end=fitting_window_end,
+        title=f"{title} - Filtered" if title else "Filtered (Forecast Focus)",
+        ax=ax_filtered,
+    )
+
+    return fig, (ax_full, ax_filtered)
+
+
 def plot_calibration_projection_grid(  # noqa: PLR0913
     location_calibration_quantiles: dict[str, pd.DataFrame] | None = None,
     location_projection_quantiles: dict[str, pd.DataFrame] | None = None,

--- a/epymodelingsuite/visualization/core.py
+++ b/epymodelingsuite/visualization/core.py
@@ -632,7 +632,7 @@ def plot_calibration_projection_sidebyside(  # noqa: PLR0913
         surveillance_size=surveillance_size,
         fitting_window_start=fitting_window_start,
         fitting_window_end=fitting_window_end,
-        title=f"{title} - Full Range" if title else "Full Range",
+        title=title,
         ax=ax_full,
     )
 
@@ -651,7 +651,7 @@ def plot_calibration_projection_sidebyside(  # noqa: PLR0913
         surveillance_size=surveillance_size,
         fitting_window_start=fitting_window_start,
         fitting_window_end=fitting_window_end,
-        title=f"{title} - Filtered" if title else "Filtered (Forecast Focus)",
+        title=title,
         ax=ax_filtered,
     )
 

--- a/epymodelingsuite/visualization/core.py
+++ b/epymodelingsuite/visualization/core.py
@@ -317,11 +317,12 @@ def plot_calibration_projection(  # noqa: PLR0913
     df_surveillance: pd.DataFrame | None = None,
     surveillance_date_col: str = "date",
     surveillance_value_col: str = "value",
-    surveillance_size: float = 30.0,
+    surveillance_size: float = 16.0,
     fitting_window_start: str | pd.Timestamp | datetime | None = None,
     fitting_window_end: str | pd.Timestamp | datetime | None = None,
     title: str | None = None,
     ax: plt.Axes | None = None,
+    weekly_x_labels: bool = False,
 ) -> tuple[plt.Figure | None, plt.Axes]:
     """
     Plot calibration and projection quantiles on top of each other for a single location.
@@ -497,6 +498,14 @@ def plot_calibration_projection(  # noqa: PLR0913
     if all_handles:
         ax.legend(all_handles, all_labels, loc="upper left", fontsize=8)
 
+    # Apply weekly x-axis labels if requested
+    if weekly_x_labels:
+        from matplotlib.dates import WeekdayLocator, DateFormatter
+        ax.xaxis.set_major_locator(WeekdayLocator(byweekday=5))  # Saturday = 5 (epiweek ending)
+        ax.xaxis.set_major_formatter(DateFormatter('%m/%d'))
+        ax.tick_params(axis='x', rotation=45)
+        plt.setp(ax.xaxis.get_majorticklabels(), ha='right')
+
     return fig, ax
 
 
@@ -513,12 +522,14 @@ def plot_calibration_projection_sidebyside(  # noqa: PLR0913
     projection_color: str = "C1",
     surveillance_date_col: str = "date",
     surveillance_value_col: str = "value",
-    surveillance_size: float = 30.0,
+    surveillance_size: float = 16.0,
     fitting_window_start: str | pd.Timestamp | datetime | None = None,
     fitting_window_end: str | pd.Timestamp | datetime | None = None,
     title: str | None = None,
     figsize: tuple[float, float] | None = None,
     spacing: float = 0.3,
+    ax_full: plt.Axes | None = None,
+    ax_filtered: plt.Axes | None = None,
 ) -> tuple[plt.Figure, tuple[plt.Axes, plt.Axes]]:
     """
     Create side-by-side quantile plots: [Full Range | Filtered].
@@ -567,6 +578,10 @@ def plot_calibration_projection_sidebyside(  # noqa: PLR0913
         Figure size. If None, defaults to (16, 6).
     spacing : float, optional
         Horizontal spacing between subplots, by default 0.3.
+    ax_full : plt.Axes | None, optional
+        Optional axes for the full panel. If provided, a new figure is not created.
+    ax_filtered : plt.Axes | None, optional
+        Optional axes for the filtered panel. If provided, a new figure is not created.
 
     Returns
     -------
@@ -593,10 +608,14 @@ def plot_calibration_projection_sidebyside(  # noqa: PLR0913
     >>> plt.close(fig)
 
     """
-    if figsize is None:
-        figsize = (16, 6)
+    fig_provided = ax_full is not None and ax_filtered is not None
 
-    fig, (ax_full, ax_filtered) = plt.subplots(1, 2, figsize=figsize, gridspec_kw={"wspace": spacing})
+    if not fig_provided:
+        if figsize is None:
+            figsize = (16, 6)
+        fig, (ax_full, ax_filtered) = plt.subplots(1, 2, figsize=figsize, gridspec_kw={"wspace": spacing})
+    else:
+        fig = ax_full.figure
 
     # Left panel: Full range
     plot_calibration_projection(
@@ -650,7 +669,7 @@ def plot_calibration_projection_grid(  # noqa: PLR0913
     location_surveillance: dict[str, pd.DataFrame] | None = None,
     surveillance_date_col: str = "date",
     surveillance_value_col: str = "value",
-    surveillance_size: float = 30.0,
+    surveillance_size: float = 16.0,
     location_fitting_window_starts: dict[str, datetime] | None = None,
     location_fitting_window_ends: dict[str, datetime] | None = None,
     panels_per_row: int = 4,

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -664,10 +664,7 @@ def generate_quantile_grid_plot(
 
     # Collect quantiles and surveillance data for each location
     location_cal_quants = {}
-    location_proj_quants_filtered = {}
-    location_proj_quants_full = {}
-    location_surveillance_filtered = {}
-    location_surveillance_full = {}
+    location_proj_quants_raw = {}
     location_fitting_window_starts = {}
     location_fitting_window_ends = {}
 
@@ -684,6 +681,8 @@ def generate_quantile_grid_plot(
         )
         if cal_quant is not None:
             location_cal_quants[loc] = cal_quant
+        if proj_quant_raw is not None:
+            location_proj_quants_raw[loc] = proj_quant_raw
 
         # Calculate fitting window start and end from calibration quantiles
         if needs_fitting_window:
@@ -707,46 +706,12 @@ def generate_quantile_grid_plot(
                 location_fitting_window_starts[loc] = dates.min()
                 location_fitting_window_ends[loc] = dates.max()
 
-        # TODO: Determine which surveillance source to use (logic will be added with per-output processing)
-        # For now, use first available source if any
-        surveillance = None
-        surveillance_config = None
-        if surveillance_data:
-            first_source = next(iter(surveillance_data.values()))
-            surveillance = first_source["data"]
-            surveillance_config = first_source["config"]
-
-        if surveillance_config:
-            df_surv_full, df_surv_filtered, surveillance_start_date = _prepare_surveillance_for_location(
-                surveillance, loc, proj_quant_raw, cal_quant, surveillance_config
-            )
-            if df_surv_full is not None:
-                location_surveillance_full[loc] = df_surv_full
-            if df_surv_filtered is not None:
-                location_surveillance_filtered[loc] = df_surv_filtered
-        else:
-            surveillance_start_date = None
-
-        proj_quant_full, proj_quant_filtered = _prepare_projection_quantiles(
-            proj_quant_raw, surveillance_start_date, plots_config
-        )
-        if proj_quant_full is not None:
-            location_proj_quants_full[loc] = proj_quant_full
-        if proj_quant_filtered is not None:
-            location_proj_quants_filtered[loc] = proj_quant_filtered
-
     # Go over collected data, plot grid, and add to output dict
-    if location_cal_quants or location_proj_quants_filtered or location_proj_quants_full:
+    if location_cal_quants or location_proj_quants_raw:
         # Rename columns to have consistent naming for plotting
         # TODO: Calibration uses "data", projection uses "hospitalizations" - make this configurable
         for loc in location_cal_quants:
             location_cal_quants[loc] = _rename_value_column(location_cal_quants[loc], "data")
-        for loc in location_proj_quants_filtered:
-            location_proj_quants_filtered[loc] = _rename_value_column(
-                location_proj_quants_filtered[loc], "hospitalizations"
-            )
-        for loc in location_proj_quants_full:
-            location_proj_quants_full[loc] = _rename_value_column(location_proj_quants_full[loc], "hospitalizations")
 
         value_col = "value"
 
@@ -754,13 +719,59 @@ def generate_quantile_grid_plot(
         for output_config in plots_config.quantiles.outputs:
             output_type_name = output_config.type.value  # "filtered", "full", or "side_by_side"
 
-            # Determine which projection data to use based on output type
-            if output_type_name == "filtered":
-                proj_quants_to_use = location_proj_quants_filtered
-                surv_data_to_use = location_surveillance_filtered
-            elif output_type_name == "full":
-                proj_quants_to_use = location_proj_quants_full
-                surv_data_to_use = location_surveillance_full
+            # Determine which surveillance source to use for this output
+            surveillance_source_name = output_config.surveillance_source
+            if surveillance_source_name is None and surveillance_data and len(surveillance_data) == 1:
+                # If only one source available and none specified, use it
+                surveillance_source_name = next(iter(surveillance_data.keys()))
+
+            # Prepare surveillance data for this output's specified source
+            location_surveillance_for_output = {}
+            surveillance_start_dates = {}
+            if output_config.show_surveillance and surveillance_source_name and surveillance_source_name in surveillance_data:
+                source = surveillance_data[surveillance_source_name]
+                surveillance_df = source["data"]
+                surveillance_config = source["config"]
+
+                for loc in location_proj_quants_raw.keys():
+                    cal_quant = location_cal_quants.get(loc)
+                    proj_quant_raw = location_proj_quants_raw.get(loc)
+
+                    df_surv_full, df_surv_filtered, surveillance_start_date = _prepare_surveillance_for_location(
+                        surveillance_df, loc, proj_quant_raw, cal_quant, surveillance_config
+                    )
+
+                    # Use the appropriate surveillance data based on output type
+                    if output_type_name == "filtered":
+                        if df_surv_filtered is not None:
+                            location_surveillance_for_output[loc] = df_surv_filtered
+                    elif output_type_name == "full":
+                        if df_surv_full is not None:
+                            location_surveillance_for_output[loc] = df_surv_full
+
+                    if surveillance_start_date is not None:
+                        surveillance_start_dates[loc] = surveillance_start_date
+
+            # Prepare projection quantiles for this output (using surveillance start dates if available)
+            location_proj_quants_for_output = {}
+            for loc, proj_quant_raw in location_proj_quants_raw.items():
+                surveillance_start_date = surveillance_start_dates.get(loc)
+                proj_quant_full, proj_quant_filtered = _prepare_projection_quantiles(
+                    proj_quant_raw, surveillance_start_date, plots_config
+                )
+
+                # Use the appropriate projection data based on output type
+                if output_type_name == "filtered":
+                    if proj_quant_filtered is not None:
+                        location_proj_quants_for_output[loc] = _rename_value_column(proj_quant_filtered, "hospitalizations")
+                elif output_type_name == "full":
+                    if proj_quant_full is not None:
+                        location_proj_quants_for_output[loc] = _rename_value_column(proj_quant_full, "hospitalizations")
+
+            # Set data to use for this output
+            if output_type_name in ["filtered", "full"]:
+                proj_quants_to_use = location_proj_quants_for_output
+                surv_data_to_use = location_surveillance_for_output
             elif output_type_name == "side_by_side":
                 # Side-by-side uses both, handled separately below
                 proj_quants_to_use = None
@@ -840,14 +851,52 @@ def generate_quantile_grid_plot(
                 # Side-by-side grid plot
                 # Grid layout: each location gets 2 panels (full + filtered)
                 try:
+                    # Prepare surveillance and projection data for both full and filtered panels
+                    location_surveillance_full_sbs = {}
+                    location_surveillance_filtered_sbs = {}
+                    location_proj_quants_full_sbs = {}
+                    location_proj_quants_filtered_sbs = {}
+                    surveillance_start_dates_sbs = {}
+
+                    if surveillance_source_name and surveillance_source_name in surveillance_data:
+                        source = surveillance_data[surveillance_source_name]
+                        surveillance_df = source["data"]
+                        surveillance_config = source["config"]
+
+                        for loc in location_proj_quants_raw.keys():
+                            cal_quant = location_cal_quants.get(loc)
+                            proj_quant_raw = location_proj_quants_raw.get(loc)
+
+                            df_surv_full, df_surv_filtered, surveillance_start_date = _prepare_surveillance_for_location(
+                                surveillance_df, loc, proj_quant_raw, cal_quant, surveillance_config
+                            )
+
+                            if df_surv_full is not None:
+                                location_surveillance_full_sbs[loc] = df_surv_full
+                            if df_surv_filtered is not None:
+                                location_surveillance_filtered_sbs[loc] = df_surv_filtered
+                            if surveillance_start_date is not None:
+                                surveillance_start_dates_sbs[loc] = surveillance_start_date
+
+                    # Prepare projection quantiles
+                    for loc, proj_quant_raw in location_proj_quants_raw.items():
+                        surveillance_start_date = surveillance_start_dates_sbs.get(loc)
+                        proj_quant_full, proj_quant_filtered = _prepare_projection_quantiles(
+                            proj_quant_raw, surveillance_start_date, plots_config
+                        )
+                        if proj_quant_full is not None:
+                            location_proj_quants_full_sbs[loc] = _rename_value_column(proj_quant_full, "hospitalizations")
+                        if proj_quant_filtered is not None:
+                            location_proj_quants_filtered_sbs[loc] = _rename_value_column(proj_quant_filtered, "hospitalizations")
+
                     # Get all locations
                     locations = set()
                     if location_cal_quants:
                         locations.update(location_cal_quants.keys())
-                    if location_proj_quants_full:
-                        locations.update(location_proj_quants_full.keys())
-                    if location_proj_quants_filtered:
-                        locations.update(location_proj_quants_filtered.keys())
+                    if location_proj_quants_full_sbs:
+                        locations.update(location_proj_quants_full_sbs.keys())
+                    if location_proj_quants_filtered_sbs:
+                        locations.update(location_proj_quants_filtered_sbs.keys())
                     locations = sorted(locations)
 
                     if locations:
@@ -874,23 +923,23 @@ def generate_quantile_grid_plot(
                                 else None
                             )
                             proj_quant_full = (
-                                location_proj_quants_full.get(location)
-                                if output_config.show_projection and location_proj_quants_full
+                                location_proj_quants_full_sbs.get(location)
+                                if output_config.show_projection and location_proj_quants_full_sbs
                                 else None
                             )
                             proj_quant_filtered = (
-                                location_proj_quants_filtered.get(location)
-                                if output_config.show_projection and location_proj_quants_filtered
+                                location_proj_quants_filtered_sbs.get(location)
+                                if output_config.show_projection and location_proj_quants_filtered_sbs
                                 else None
                             )
 
                             surv_full = None
                             if (
                                 output_config.show_surveillance
-                                and location_surveillance_full
-                                and location in location_surveillance_full
+                                and location_surveillance_full_sbs
+                                and location in location_surveillance_full_sbs
                             ):
-                                surv_full = location_surveillance_full[location].copy()
+                                surv_full = location_surveillance_full_sbs[location].copy()
                                 if output_config.full_panel:
                                     if output_config.full_panel.surveillance_start_date is not None:
                                         start_date = pd.to_datetime(
@@ -906,10 +955,10 @@ def generate_quantile_grid_plot(
                             surv_filtered = None
                             if (
                                 output_config.show_surveillance
-                                and location_surveillance_filtered
-                                and location in location_surveillance_filtered
+                                and location_surveillance_filtered_sbs
+                                and location in location_surveillance_filtered_sbs
                             ):
-                                surv_filtered = location_surveillance_filtered[location].copy()
+                                surv_filtered = location_surveillance_filtered_sbs[location].copy()
                                 if output_config.filtered_panel:
                                     if output_config.filtered_panel.surveillance_start_date is not None:
                                         start_date = pd.to_datetime(

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -19,6 +19,7 @@ from .core import (
     figure_to_output_object,
     plot_calibration_projection,
     plot_calibration_projection_grid,
+    plot_calibration_projection_sidebyside,
     plot_posterior_histogram,
     plot_posterior_histogram_grid,
 )
@@ -120,6 +121,64 @@ def _create_full_plot(
         calibration_color=plots_config.quantiles.calibration.color,
         projection_color=plots_config.quantiles.projection.color,
         df_surveillance=df_surv,
+        fitting_window_start=fitting_window_start if plots_config.quantiles.fitting_window_line.show else None,
+        fitting_window_end=fitting_window_end if plots_config.quantiles.fitting_window_line.show else None,
+        title=_format_location_name(location),
+    )
+
+
+def _create_sidebyside_plot(
+    location: str,
+    cal_quant: pd.DataFrame | None,
+    proj_quant_full: pd.DataFrame | None,
+    proj_quant_filtered: pd.DataFrame | None,
+    df_surv_full: pd.DataFrame | None,
+    df_surv_filtered: pd.DataFrame | None,
+    fitting_window_start: pd.Timestamp | None,
+    fitting_window_end: pd.Timestamp | None,
+    plots_config: PlotsConfig,
+    value_col: str,
+) -> tuple:
+    """
+    Create side-by-side (full | filtered) quantile plot for a location.
+
+    Parameters
+    ----------
+    location : str
+        Location name
+    cal_quant : pd.DataFrame or None
+        Calibration quantiles (shown in both panels)
+    proj_quant_full : pd.DataFrame or None
+        Projection quantiles for left panel (full version)
+    proj_quant_filtered : pd.DataFrame or None
+        Projection quantiles for right panel (filtered version)
+    df_surv_full : pd.DataFrame or None
+        Surveillance data for left panel (full version)
+    df_surv_filtered : pd.DataFrame or None
+        Surveillance data for right panel (filtered version)
+    fitting_window_start : pd.Timestamp or None
+        Start of fitting window
+    fitting_window_end : pd.Timestamp or None
+        End of fitting window
+    plots_config : PlotsConfig
+        Plot configuration
+    value_col : str
+        Name of value column
+
+    Returns
+    -------
+    tuple
+        (fig, (ax_full, ax_filtered)) matplotlib figure and tuple of axes
+    """
+    return plot_calibration_projection_sidebyside(
+        calibration_quantiles=cal_quant,
+        projection_quantiles_full=proj_quant_full,
+        projection_quantiles_filtered=proj_quant_filtered,
+        surveillance_full=df_surv_full,
+        surveillance_filtered=df_surv_filtered,
+        value_col=value_col,
+        calibration_color=plots_config.quantiles.calibration.color,
+        projection_color=plots_config.quantiles.projection.color,
         fitting_window_start=fitting_window_start if plots_config.quantiles.fitting_window_line.show else None,
         fitting_window_end=fitting_window_end if plots_config.quantiles.fitting_window_line.show else None,
         title=_format_location_name(location),
@@ -408,6 +467,32 @@ def generate_single_quantile_plots(
         except Exception as e:
             logger.warning("Failed to create full quantile plot for %s: %s", location, e)
 
+        # Create side-by-side plot
+        try:
+            fig, (ax_full, ax_filtered) = _create_sidebyside_plot(
+                location,
+                cal_quant,
+                proj_quant_full,
+                proj_quant_filtered,
+                df_surv_full,
+                df_surv_filtered,
+                fitting_window_start,
+                fitting_window_end,
+                plots_config,
+                value_col,
+            )
+
+            # Package output
+            output_objs = []
+            for output_type in plots_config.figure_output_types:
+                output_objs.append(
+                    figure_to_output_object(fig, f"quantiles_{location}_sidebyside", output_type, plots_config.dpi)
+                )
+            out_dict[f"quantiles_{location}_sidebyside"] = output_objs
+            plt.close(fig)
+        except Exception as e:
+            logger.warning("Failed to create sidebyside quantile plot for %s: %s", location, e)
+
 
 def generate_quantile_grid_plot(
     calibrations: list[CalibrationOutput],
@@ -690,6 +775,116 @@ def generate_quantile_grid_plot(
             plt.close(fig)
         except Exception as e:
             logger.warning("Failed to create full quantile grid plot: %s", e)
+
+        # Create side-by-side grid plot
+        # Grid layout: each location gets 2 panels (full + filtered)
+        # If panels_per_row=4, that's 2 location-pairs per row
+        try:
+            # Get all locations
+            locations = set()
+            if location_cal_quants:
+                locations.update(location_cal_quants.keys())
+            if location_proj_quants_full:
+                locations.update(location_proj_quants_full.keys())
+            if location_proj_quants_filtered:
+                locations.update(location_proj_quants_filtered.keys())
+            locations = sorted(locations)
+
+            if locations:
+                n_locations = len(locations)
+                panels_per_row = plots_config.quantiles.grid.panels_per_row
+                pairs_per_row = panels_per_row // 2  # Each location needs 2 panels
+                nrows = math.ceil(n_locations / pairs_per_row)
+                ncols = panels_per_row
+
+                figsize = (4 * ncols, 3.6 * nrows)
+                fig, axes = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
+
+                for i, location in enumerate(locations):
+                    pair_idx = i  # Which location-pair (0, 1, 2, ...)
+                    row = pair_idx // pairs_per_row
+                    col_start = (pair_idx % pairs_per_row) * 2  # 0, 2, 4, ...
+
+                    ax_full = axes[row, col_start]  # Left panel of pair
+                    ax_filtered = axes[row, col_start + 1]  # Right panel of pair
+
+                    cal_quant = location_cal_quants.get(location) if location_cal_quants else None
+                    proj_quant_full = location_proj_quants_full.get(location) if location_proj_quants_full else None
+                    proj_quant_filtered = (
+                        location_proj_quants_filtered.get(location) if location_proj_quants_filtered else None
+                    )
+                    surv_full = location_surveillance_full.get(location) if location_surveillance_full else None
+                    surv_filtered = (
+                        location_surveillance_filtered.get(location) if location_surveillance_filtered else None
+                    )
+                    fitting_window_start = (
+                        location_fitting_window_starts.get(location) if location_fitting_window_starts else None
+                    )
+                    fitting_window_end = (
+                        location_fitting_window_ends.get(location) if location_fitting_window_ends else None
+                    )
+
+                    # Left panel: Full
+                    plot_calibration_projection(
+                        calibration_quantiles=cal_quant,
+                        projection_quantiles=proj_quant_full,
+                        value_col=value_col,
+                        calibration_color=plots_config.quantiles.calibration.color,
+                        projection_color=plots_config.quantiles.projection.color,
+                        df_surveillance=surv_full,
+                        fitting_window_start=(
+                            fitting_window_start if plots_config.quantiles.fitting_window_line.show else None
+                        ),
+                        fitting_window_end=(
+                            fitting_window_end if plots_config.quantiles.fitting_window_line.show else None
+                        ),
+                        title=f"{_format_location_name(location)} - Full",
+                        ax=ax_full,
+                    )
+
+                    # Right panel: Filtered
+                    plot_calibration_projection(
+                        calibration_quantiles=cal_quant,
+                        projection_quantiles=proj_quant_filtered,
+                        value_col=value_col,
+                        calibration_color=plots_config.quantiles.calibration.color,
+                        projection_color=plots_config.quantiles.projection.color,
+                        df_surveillance=surv_filtered,
+                        fitting_window_start=(
+                            fitting_window_start if plots_config.quantiles.fitting_window_line.show else None
+                        ),
+                        fitting_window_end=(
+                            fitting_window_end if plots_config.quantiles.fitting_window_line.show else None
+                        ),
+                        title=f"{_format_location_name(location)} - Filtered",
+                        ax=ax_filtered,
+                    )
+
+                    # Hide legends except for first pair
+                    if i != 0:
+                        for ax in [ax_full, ax_filtered]:
+                            legend = ax.get_legend()
+                            if legend is not None:
+                                legend.remove()
+
+                # Remove unused axes
+                for idx in range(n_locations * 2, nrows * ncols):
+                    r = idx // ncols
+                    c = idx % ncols
+                    axes[r, c].axis("off")
+
+                plt.tight_layout()
+
+                # Package output
+                output_objs = []
+                for output_type in plots_config.figure_output_types:
+                    output_objs.append(
+                        figure_to_output_object(fig, "quantiles_grid_sidebyside", output_type, plots_config.dpi)
+                    )
+                out_dict["quantiles_grid_sidebyside"] = output_objs
+                plt.close(fig)
+        except Exception as e:
+            logger.warning("Failed to create sidebyside quantile grid plot: %s", e)
 
 
 def generate_single_location_posterior_plots(

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -111,27 +111,42 @@ def _prepare_surveillance_for_location(
         return df_surv_full, df_surv_filtered, surveillance_start_date
 
     surv = get_data_in_location(surveillance, location, plots_config.quantiles.surveillance.location_column)
-    date_col = plots_config.quantiles.surveillance.date_column
-    value_col = plots_config.quantiles.surveillance.value_column
 
     # Full surveillance (no filtering)
-    if not surv.empty and date_col and value_col:
-        df_surv_full = surv.rename(columns={date_col: "date", value_col: "value"})[["date", "value"]]
+    if (
+        not surv.empty
+        and plots_config.quantiles.surveillance.date_column
+        and plots_config.quantiles.surveillance.value_column
+    ):
+        df_surv_full = surv.rename(
+            columns={
+                plots_config.quantiles.surveillance.date_column: "date",
+                plots_config.quantiles.surveillance.value_column: "value",
+            }
+        )[["date", "value"]]
 
     # Filtered surveillance
     surv_filtered = surv.copy()
 
-    if not surv_filtered.empty and date_col:
-        # Align surveillance window with available quantiles
+    if not surv_filtered.empty:
         quantiles_for_timespan = proj_quant if proj_quant is not None else cal_quant
         if quantiles_for_timespan is not None and "date" in quantiles_for_timespan.columns:
             timespan_start = pd.to_datetime(quantiles_for_timespan["date"]).min().date()
             surv_filtered = surv_filtered[
-                pd.to_datetime(surv_filtered[date_col]).dt.date >= timespan_start
+                pd.to_datetime(surv_filtered[plots_config.quantiles.surveillance.date_column]).dt.date >= timespan_start
             ]
 
-    if not surv_filtered.empty and date_col and value_col:
-        df_surv_filtered = surv_filtered.rename(columns={date_col: "date", value_col: "value"})[["date", "value"]]
+    if (
+        not surv_filtered.empty
+        and plots_config.quantiles.surveillance.date_column
+        and plots_config.quantiles.surveillance.value_column
+    ):
+        df_surv_filtered = surv_filtered.rename(
+            columns={
+                plots_config.quantiles.surveillance.date_column: "date",
+                plots_config.quantiles.surveillance.value_column: "value",
+            }
+        )[["date", "value"]]
 
         if not df_surv_filtered.empty:
             surveillance_start_date = pd.to_datetime(df_surv_filtered["date"]).min().date()
@@ -465,26 +480,25 @@ def generate_single_quantile_plots(
         # Calculate fitting window start and end from calibration quantiles
         fitting_window_start = None
         fitting_window_end = None
-    if needs_fitting_window:
-        cal_quant_for_fitting = cal_quant
-        if cal_quant_for_fitting is None:
-            try:
-                cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
-                    quantiles=[0.5],  # Only need one quantile to get dates
-                    variables=["date", "data"],
-                )
-            except (ValueError, AttributeError, TypeError) as e:
-                logger.warning(
-                    "Failed to get calibration quantiles for fitting window for %s: %s",
-                    location,
-                    e,
-                )
+        if needs_fitting_window:
+            cal_quant_for_fitting = cal_quant
+            if cal_quant_for_fitting is None:
+                try:
+                    cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
+                        quantiles=[0.5],  # Only need one quantile to get dates
+                        variables=["date", "data"],
+                    )
+                except (ValueError, AttributeError, TypeError) as e:
+                    logger.warning(
+                        "Failed to get calibration quantiles for fitting window for %s: %s",
+                        location,
+                        e,
+                    )
 
-        if cal_quant_for_fitting is not None and "date" in cal_quant_for_fitting.columns:
-            # Use calibration dates to mark fitting window on plots
-            dates = pd.to_datetime(cal_quant_for_fitting["date"]).dt.date
-            fitting_window_start = dates.min()
-            fitting_window_end = dates.max()
+            if cal_quant_for_fitting is not None and "date" in cal_quant_for_fitting.columns:
+                dates = pd.to_datetime(cal_quant_for_fitting["date"]).dt.date
+                fitting_window_start = dates.min()
+                fitting_window_end = dates.max()
 
         df_surv_full, df_surv_filtered, surveillance_start_date = _prepare_surveillance_for_location(
             surveillance, location, proj_quant, cal_quant, plots_config
@@ -496,7 +510,6 @@ def generate_single_quantile_plots(
 
         # Rename columns to have consistent naming for plotting
         # TODO: Calibration uses "data", projection uses "hospitalizations" - make this configurable
-        # Normalizing to "value" means the plotting primitives don't need to know source-specific names
         cal_quant = _rename_value_column(cal_quant, "data")
         proj_quant_filtered = _rename_value_column(proj_quant_filtered, "hospitalizations")
         proj_quant_full = _rename_value_column(proj_quant_full, "hospitalizations")
@@ -508,53 +521,70 @@ def generate_single_quantile_plots(
             output_name = f"quantiles_{location}_{output_config.type.value}"
 
             try:
-                if output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
-                    # Side-by-side needs per-panel copies so each panel can apply its own trims
-                    proj_quant_full_for_output = proj_quant_full.copy() if proj_quant_full is not None else None
-                    proj_quant_filtered_for_output = (
-                        proj_quant_filtered.copy() if proj_quant_filtered is not None else None
+                # Determine which data to use and apply per-output filtering
+                if output_config.type == QuantilesOutputTypeEnum.FILTERED:
+                    proj_to_use = proj_quant_filtered
+                    surv_to_use = df_surv_filtered
+                elif output_config.type == QuantilesOutputTypeEnum.FULL:
+                    proj_to_use = proj_quant_full
+                    surv_to_use = df_surv_full
+                elif output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
+                    # Side-by-side handled separately below
+                    proj_to_use = None
+                    surv_to_use = None
+                else:
+                    logger.warning("Unknown output type %s for %s", output_config.type, location)
+                    continue
+
+                # Apply per-output surveillance filtering if needed (for filtered/full types)
+                if surv_to_use is not None:
+                    # Date-based filtering takes precedence over points-based filtering
+                    if output_config.surveillance_start_date is not None:
+                        start_date = pd.to_datetime(output_config.surveillance_start_date).date()
+                        surv_dates = pd.to_datetime(surv_to_use["date"]).dt.date
+                        surv_to_use = surv_to_use[surv_dates >= start_date]
+                    elif output_config.surveillance_points is not None:
+                        surv_to_use = surv_to_use.sort_values("date").tail(output_config.surveillance_points)
+
+                # Apply per-output horizon_max if specified (overrides base config)
+                if proj_to_use is not None and output_config.horizon_max is not None:
+                    proj_dates = pd.to_datetime(proj_to_use["date"]).dt.date
+                    horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
+                    proj_to_use = proj_to_use[proj_dates.values <= horizon_end]
+
+                # Create the plot
+                if output_config.type == QuantilesOutputTypeEnum.FILTERED:
+                    fig, ax = _create_filtered_plot(
+                        location,
+                        cal_quant,
+                        proj_to_use,
+                        surv_to_use,
+                        fitting_window_start,
+                        fitting_window_end,
+                        plots_config,
+                        value_col,
+                        output_config,
                     )
-
-                    # Apply per-output horizon and surveillance trims on copies so base data stays reusable
-                    if output_config.horizon_max is not None:
-                        horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
-                        if proj_quant_full_for_output is not None:
-                            proj_dates = pd.to_datetime(proj_quant_full_for_output["date"]).dt.date
-                            proj_quant_full_for_output = proj_quant_full_for_output[proj_dates.values <= horizon_end]
-                        if proj_quant_filtered_for_output is not None:
-                            proj_dates = pd.to_datetime(proj_quant_filtered_for_output["date"]).dt.date
-                            proj_quant_filtered_for_output = proj_quant_filtered_for_output[
-                                proj_dates.values <= horizon_end
-                            ]
-
-                    surv_full = df_surv_full.copy() if df_surv_full is not None else None
-                    surv_filtered = df_surv_filtered.copy() if df_surv_filtered is not None else None
-
-                    if output_config.full_panel and surv_full is not None:
-                        if output_config.full_panel.surveillance_start_date is not None:
-                            start_date = pd.to_datetime(output_config.full_panel.surveillance_start_date).date()
-                            surv_dates = pd.to_datetime(surv_full["date"]).dt.date
-                            surv_full = surv_full[surv_dates >= start_date]
-                        elif output_config.full_panel.surveillance_points is not None:
-                            surv_full = surv_full.sort_values("date").tail(output_config.full_panel.surveillance_points)
-
-                    if output_config.filtered_panel and surv_filtered is not None:
-                        if output_config.filtered_panel.surveillance_start_date is not None:
-                            start_date = pd.to_datetime(output_config.filtered_panel.surveillance_start_date).date()
-                            surv_dates = pd.to_datetime(surv_filtered["date"]).dt.date
-                            surv_filtered = surv_filtered[surv_dates >= start_date]
-                        elif output_config.filtered_panel.surveillance_points is not None:
-                            surv_filtered = surv_filtered.sort_values("date").tail(
-                                output_config.filtered_panel.surveillance_points
-                            )
-
+                elif output_config.type == QuantilesOutputTypeEnum.FULL:
+                    fig, ax = _create_full_plot(
+                        location,
+                        cal_quant,
+                        proj_to_use,
+                        surv_to_use,
+                        fitting_window_start,
+                        fitting_window_end,
+                        plots_config,
+                        value_col,
+                        output_config,
+                    )
+                elif output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
                     fig, (ax_full, ax_filtered) = _create_sidebyside_plot(
                         location,
                         cal_quant,
-                        proj_quant_full_for_output,
-                        proj_quant_filtered_for_output,
-                        surv_full,
-                        surv_filtered,
+                        proj_quant_full,
+                        proj_quant_filtered,
+                        df_surv_full,
+                        df_surv_filtered,
                         fitting_window_start,
                         fitting_window_end,
                         plots_config,
@@ -562,62 +592,8 @@ def generate_single_quantile_plots(
                         output_config,
                     )
                 else:
-                    # Determine which data to use and apply per-output filtering
-                    if output_config.type == QuantilesOutputTypeEnum.FILTERED:
-                        proj_to_use = proj_quant_filtered
-                        surv_to_use = df_surv_filtered
-                    elif output_config.type == QuantilesOutputTypeEnum.FULL:
-                        proj_to_use = proj_quant_full
-                        surv_to_use = df_surv_full
-                    else:
-                        logger.warning("Unknown output type %s for %s", output_config.type, location)
-                        continue
-
-                    # Apply per-output surveillance filtering if needed (for filtered/full types)
-                    if surv_to_use is not None:
-                        # Date-based filtering takes precedence over points-based filtering
-                        if output_config.surveillance_start_date is not None:
-                            start_date = pd.to_datetime(output_config.surveillance_start_date).date()
-                            surv_dates = pd.to_datetime(surv_to_use["date"]).dt.date
-                            surv_to_use = surv_to_use[surv_dates >= start_date]
-                        elif output_config.surveillance_points is not None:
-                            surv_to_use = surv_to_use.sort_values("date").tail(output_config.surveillance_points)
-
-                    # Apply per-output horizon_max if specified (overrides base config)
-                    if proj_to_use is not None and output_config.horizon_max is not None:
-                        # Per-output horizon can be tighter than the base config
-                        proj_dates = pd.to_datetime(proj_to_use["date"]).dt.date
-                        horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
-                        proj_to_use = proj_to_use[proj_dates.values <= horizon_end]
-
-                    # Create the plot
-                    if output_config.type == QuantilesOutputTypeEnum.FILTERED:
-                        fig, ax = _create_filtered_plot(
-                            location,
-                            cal_quant,
-                            proj_to_use,
-                            surv_to_use,
-                            fitting_window_start,
-                            fitting_window_end,
-                            plots_config,
-                            value_col,
-                            output_config,
-                        )
-                    elif output_config.type == QuantilesOutputTypeEnum.FULL:
-                        fig, ax = _create_full_plot(
-                            location,
-                            cal_quant,
-                            proj_to_use,
-                            surv_to_use,
-                            fitting_window_start,
-                            fitting_window_end,
-                            plots_config,
-                            value_col,
-                            output_config,
-                        )
-                    else:
-                        logger.warning("Unknown output type %s for %s", output_config.type, location)
-                        continue
+                    logger.warning("Unknown output type %s for %s", output_config.type, location)
+                    continue
 
                 # Package output
                 output_objs = []
@@ -855,13 +831,10 @@ def generate_quantile_grid_plot(
 
                     if locations:
                         n_locations = len(locations)
-                        configured_panels = plots_config.quantiles.grid.panels_per_row
-                        ncols = configured_panels + (configured_panels % 2)  # keep even count for pairs
-                        if ncols < 2:
-                            logger.warning("panels_per_row must be >= 2 for side_by_side; defaulting to 2 columns")
-                            ncols = 2
-                        pairs_per_row = ncols // 2  # Each location needs 2 panels
+                        panels_per_row = plots_config.quantiles.grid.panels_per_row
+                        pairs_per_row = panels_per_row // 2  # Each location needs 2 panels
                         nrows = math.ceil(n_locations / pairs_per_row)
+                        ncols = panels_per_row
 
                         figsize = output_config.figsize if output_config.figsize else (4 * ncols, 3.6 * nrows)
                         fig, axes = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
@@ -889,16 +862,6 @@ def generate_quantile_grid_plot(
                                 if output_config.show_projection and location_proj_quants_filtered
                                 else None
                             )
-
-                            # Apply per-output horizon override to both panels
-                            if output_config.horizon_max is not None:
-                                horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
-                                if proj_quant_full is not None:
-                                    proj_dates = pd.to_datetime(proj_quant_full["date"]).dt.date
-                                    proj_quant_full = proj_quant_full[proj_dates.values <= horizon_end]
-                                if proj_quant_filtered is not None:
-                                    proj_dates = pd.to_datetime(proj_quant_filtered["date"]).dt.date
-                                    proj_quant_filtered = proj_quant_filtered[proj_dates.values <= horizon_end]
 
                             surv_full = None
                             if (

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -36,6 +36,7 @@ def _create_filtered_plot(
     fitting_window_end: pd.Timestamp | None,
     plots_config: PlotsConfig,
     value_col: str,
+    output_config,
 ) -> tuple:
     """
     Create filtered quantile plot for a location.
@@ -58,6 +59,8 @@ def _create_filtered_plot(
         Plot configuration
     value_col : str
         Name of value column
+    output_config : QuantilesOutputConfig
+        Output configuration with show flags
 
     Returns
     -------
@@ -65,14 +68,14 @@ def _create_filtered_plot(
         (fig, ax) matplotlib figure and axes
     """
     return plot_calibration_projection(
-        calibration_quantiles=cal_quant,
-        projection_quantiles=proj_quant,
+        calibration_quantiles=cal_quant if output_config.show_calibration else None,
+        projection_quantiles=proj_quant if output_config.show_projection else None,
         value_col=value_col,
         calibration_color=plots_config.quantiles.calibration.color,
         projection_color=plots_config.quantiles.projection.color,
-        df_surveillance=df_surv,
-        fitting_window_start=fitting_window_start if plots_config.quantiles.fitting_window_line.show else None,
-        fitting_window_end=fitting_window_end if plots_config.quantiles.fitting_window_line.show else None,
+        df_surveillance=df_surv if output_config.show_surveillance else None,
+        fitting_window_start=fitting_window_start if output_config.show_fitting_window_line else None,
+        fitting_window_end=fitting_window_end if output_config.show_fitting_window_line else None,
         title=_format_location_name(location),
     )
 
@@ -86,6 +89,7 @@ def _create_full_plot(
     fitting_window_end: pd.Timestamp | None,
     plots_config: PlotsConfig,
     value_col: str,
+    output_config,
 ) -> tuple:
     """
     Create full quantile plot for a location.
@@ -108,6 +112,8 @@ def _create_full_plot(
         Plot configuration
     value_col : str
         Name of value column
+    output_config : QuantilesOutputConfig
+        Output configuration with show flags
 
     Returns
     -------
@@ -115,14 +121,14 @@ def _create_full_plot(
         (fig, ax) matplotlib figure and axes
     """
     return plot_calibration_projection(
-        calibration_quantiles=cal_quant,
-        projection_quantiles=proj_quant,
+        calibration_quantiles=cal_quant if output_config.show_calibration else None,
+        projection_quantiles=proj_quant if output_config.show_projection else None,
         value_col=value_col,
         calibration_color=plots_config.quantiles.calibration.color,
         projection_color=plots_config.quantiles.projection.color,
-        df_surveillance=df_surv,
-        fitting_window_start=fitting_window_start if plots_config.quantiles.fitting_window_line.show else None,
-        fitting_window_end=fitting_window_end if plots_config.quantiles.fitting_window_line.show else None,
+        df_surveillance=df_surv if output_config.show_surveillance else None,
+        fitting_window_start=fitting_window_start if output_config.show_fitting_window_line else None,
+        fitting_window_end=fitting_window_end if output_config.show_fitting_window_line else None,
         title=_format_location_name(location),
     )
 
@@ -138,6 +144,7 @@ def _create_sidebyside_plot(
     fitting_window_end: pd.Timestamp | None,
     plots_config: PlotsConfig,
     value_col: str,
+    output_config,
 ) -> tuple:
     """
     Create side-by-side (full | filtered) quantile plot for a location.
@@ -164,6 +171,8 @@ def _create_sidebyside_plot(
         Plot configuration
     value_col : str
         Name of value column
+    output_config : QuantilesOutputConfig
+        Output configuration with show flags
 
     Returns
     -------
@@ -171,17 +180,19 @@ def _create_sidebyside_plot(
         (fig, (ax_full, ax_filtered)) matplotlib figure and tuple of axes
     """
     return plot_calibration_projection_sidebyside(
-        calibration_quantiles=cal_quant,
-        projection_quantiles_full=proj_quant_full,
-        projection_quantiles_filtered=proj_quant_filtered,
-        surveillance_full=df_surv_full,
-        surveillance_filtered=df_surv_filtered,
+        calibration_quantiles=cal_quant if output_config.show_calibration else None,
+        projection_quantiles_full=proj_quant_full if output_config.show_projection else None,
+        projection_quantiles_filtered=proj_quant_filtered if output_config.show_projection else None,
+        surveillance_full=df_surv_full if output_config.show_surveillance else None,
+        surveillance_filtered=df_surv_filtered if output_config.show_surveillance else None,
         value_col=value_col,
         calibration_color=plots_config.quantiles.calibration.color,
         projection_color=plots_config.quantiles.projection.color,
-        fitting_window_start=fitting_window_start if plots_config.quantiles.fitting_window_line.show else None,
-        fitting_window_end=fitting_window_end if plots_config.quantiles.fitting_window_line.show else None,
+        fitting_window_start=fitting_window_start if output_config.show_fitting_window_line else None,
+        fitting_window_end=fitting_window_end if output_config.show_fitting_window_line else None,
         title=_format_location_name(location),
+        figsize=output_config.figsize,
+        spacing=output_config.spacing,
     )
 
 
@@ -242,9 +253,10 @@ def generate_single_quantile_plots(
 
     locations = get_locations_to_plot(calibrations, plots_config.quantiles.single)
 
-    # Load surveillance data once before loop
+    # Load surveillance data once before loop if any output needs it
     surveillance = None
-    if plots_config.quantiles.surveillance.show and plots_config.quantiles.surveillance.data_path:
+    needs_surveillance = any(output.show_surveillance for output in plots_config.quantiles.outputs)
+    if needs_surveillance and plots_config.quantiles.surveillance.data_path:
         try:
             surveillance = pd.read_csv(plots_config.quantiles.surveillance.data_path)
         except Exception as e:
@@ -265,9 +277,14 @@ def generate_single_quantile_plots(
 
         # Get pre-computed quantiles
 
+        # Check if any output needs calibration/projection/fitting window
+        needs_calibration = any(output.show_calibration for output in plots_config.quantiles.outputs)
+        needs_projection = any(output.show_projection for output in plots_config.quantiles.outputs)
+        needs_fitting_window = any(output.show_fitting_window_line for output in plots_config.quantiles.outputs)
+
         # Calibration quantiles
         cal_quant = None
-        if plots_config.quantiles.calibration.show:
+        if needs_calibration:
             try:
                 cal_quant = calibration.results.get_calibration_quantiles(
                     quantiles=plots_config.quantiles.quantiles,
@@ -283,7 +300,7 @@ def generate_single_quantile_plots(
         # Calculate fitting window start and end from calibration quantiles
         fitting_window_start = None
         fitting_window_end = None
-        if plots_config.quantiles.fitting_window_line.show:
+        if needs_fitting_window:
             # Fetch calibration quantiles for fitting window calculation even if not displaying them
             cal_quant_for_fitting = cal_quant
             if cal_quant_for_fitting is None:
@@ -307,7 +324,7 @@ def generate_single_quantile_plots(
         # Projection quantiles
         # TODO: "hospitalizations" column is hardcoded in projection quantiles
         proj_quant = None
-        if plots_config.quantiles.projection.show:
+        if needs_projection:
             try:
                 proj_quant = calibration.results.get_projection_quantiles(
                     quantiles=plots_config.quantiles.quantiles,
@@ -419,79 +436,63 @@ def generate_single_quantile_plots(
 
         value_col = "value"
 
-        # Create filtered plot
-        try:
-            fig, ax = _create_filtered_plot(
-                location,
-                cal_quant,
-                proj_quant_filtered,
-                df_surv_filtered,
-                fitting_window_start,
-                fitting_window_end,
-                plots_config,
-                value_col,
-            )
+        # Create plots for each configured output
+        from ..schema.output import QuantilesOutputTypeEnum
 
-            # Package output
-            output_objs = []
-            for output_type in plots_config.figure_output_types:
-                output_objs.append(
-                    figure_to_output_object(fig, f"quantiles_{location}_filtered", output_type, plots_config.dpi)
-                )
-            out_dict[f"quantiles_{location}_filtered"] = output_objs
-            plt.close(fig)
-        except Exception as e:
-            logger.warning("Failed to create filtered quantile plot for %s: %s", location, e)
+        for output_config in plots_config.quantiles.outputs:
+            output_name = f"quantiles_{location}_{output_config.type.value}"
 
-        # Create full plot
-        try:
-            fig, ax = _create_full_plot(
-                location,
-                cal_quant,
-                proj_quant_full,
-                df_surv_full,
-                fitting_window_start,
-                fitting_window_end,
-                plots_config,
-                value_col,
-            )
+            try:
+                if output_config.type == QuantilesOutputTypeEnum.FILTERED:
+                    fig, ax = _create_filtered_plot(
+                        location,
+                        cal_quant,
+                        proj_quant_filtered,
+                        df_surv_filtered,
+                        fitting_window_start,
+                        fitting_window_end,
+                        plots_config,
+                        value_col,
+                        output_config,
+                    )
+                elif output_config.type == QuantilesOutputTypeEnum.FULL:
+                    fig, ax = _create_full_plot(
+                        location,
+                        cal_quant,
+                        proj_quant_full,
+                        df_surv_full,
+                        fitting_window_start,
+                        fitting_window_end,
+                        plots_config,
+                        value_col,
+                        output_config,
+                    )
+                elif output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
+                    fig, (ax_full, ax_filtered) = _create_sidebyside_plot(
+                        location,
+                        cal_quant,
+                        proj_quant_full,
+                        proj_quant_filtered,
+                        df_surv_full,
+                        df_surv_filtered,
+                        fitting_window_start,
+                        fitting_window_end,
+                        plots_config,
+                        value_col,
+                        output_config,
+                    )
+                else:
+                    logger.warning("Unknown output type %s for %s", output_config.type, location)
+                    continue
 
-            # Package output
-            output_objs = []
-            for output_type in plots_config.figure_output_types:
-                output_objs.append(
-                    figure_to_output_object(fig, f"quantiles_{location}_full", output_type, plots_config.dpi)
-                )
-            out_dict[f"quantiles_{location}_full"] = output_objs
-            plt.close(fig)
-        except Exception as e:
-            logger.warning("Failed to create full quantile plot for %s: %s", location, e)
-
-        # Create side-by-side plot
-        try:
-            fig, (ax_full, ax_filtered) = _create_sidebyside_plot(
-                location,
-                cal_quant,
-                proj_quant_full,
-                proj_quant_filtered,
-                df_surv_full,
-                df_surv_filtered,
-                fitting_window_start,
-                fitting_window_end,
-                plots_config,
-                value_col,
-            )
-
-            # Package output
-            output_objs = []
-            for output_type in plots_config.figure_output_types:
-                output_objs.append(
-                    figure_to_output_object(fig, f"quantiles_{location}_sidebyside", output_type, plots_config.dpi)
-                )
-            out_dict[f"quantiles_{location}_sidebyside"] = output_objs
-            plt.close(fig)
-        except Exception as e:
-            logger.warning("Failed to create sidebyside quantile plot for %s: %s", location, e)
+                # Package output
+                output_objs = []
+                for figure_output_type in plots_config.figure_output_types:
+                    output_objs.append(figure_to_output_object(fig, output_name, figure_output_type, plots_config.dpi))
+                out_dict[output_name] = output_objs
+                plt.close(fig)
+            except Exception as e:
+                logger.warning("Failed to create %s quantile plot for %s: %s", output_config.type.value, location, e)
 
 
 def generate_quantile_grid_plot(
@@ -527,9 +528,10 @@ def generate_quantile_grid_plot(
     if not plots_config.quantiles.grid.enabled:
         return
 
-    # Load surveillance data once before loop
+    # Load surveillance data once before loop if any output needs it
     surveillance = None
-    if plots_config.quantiles.surveillance.show and plots_config.quantiles.surveillance.data_path:
+    needs_surveillance = any(output.show_surveillance for output in plots_config.quantiles.outputs)
+    if needs_surveillance and plots_config.quantiles.surveillance.data_path:
         try:
             surveillance = pd.read_csv(plots_config.quantiles.surveillance.data_path)
         except Exception as e:
@@ -556,8 +558,13 @@ def generate_quantile_grid_plot(
 
         # Get pre-computed quantiles
 
+        # Check if any output needs calibration/projection/fitting window
+        needs_calibration = any(output.show_calibration for output in plots_config.quantiles.outputs)
+        needs_projection = any(output.show_projection for output in plots_config.quantiles.outputs)
+        needs_fitting_window = any(output.show_fitting_window_line for output in plots_config.quantiles.outputs)
+
         # Calibration quantiles
-        if plots_config.quantiles.calibration.show:
+        if needs_calibration:
             try:
                 location_cal_quants[loc] = calibration.results.get_calibration_quantiles(
                     quantiles=plots_config.quantiles.quantiles,
@@ -571,7 +578,7 @@ def generate_quantile_grid_plot(
                 )
 
         # Calculate fitting window start and end from calibration quantiles
-        if plots_config.quantiles.fitting_window_line.show:
+        if needs_fitting_window:
             # Fetch calibration quantiles for fitting window calculation even if not displaying them
             cal_quant_for_fitting = location_cal_quants.get(loc)
             if cal_quant_for_fitting is None:
@@ -595,7 +602,7 @@ def generate_quantile_grid_plot(
         # Projection quantiles
         # TODO: "hospitalizations" column is hardcoded in projection quantiles
         proj_quant_raw = None
-        if plots_config.quantiles.projection.show:
+        if needs_projection:
             try:
                 proj_quant_raw = calibration.results.get_projection_quantiles(
                     quantiles=plots_config.quantiles.quantiles,

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -14,7 +14,13 @@ import pandas as pd
 
 from ..builders.utils import get_data_in_location
 from ..schema.dispatcher import CalibrationOutput
-from ..schema.output import ObservedValuesConfig, OutputObject, PlotsConfig, QuantilesOutputConfig, QuantilesOutputTypeEnum
+from ..schema.output import (
+    ObservedValuesConfig,
+    OutputObject,
+    PlotsConfig,
+    QuantilesOutputConfig,
+    QuantilesOutputTypeEnum,
+)
 from .core import (
     _format_location_name,
     figure_to_output_object,
@@ -439,6 +445,7 @@ def generate_single_quantile_plots(
         return
 
     locations = get_locations_to_plot(calibrations, plots_config.quantiles.single)
+    logger.info("Generating single-location quantile plots for %d locations", len(locations))
 
     # Load surveillance data once before loop if any output needs it
     surveillance_data = {}
@@ -525,6 +532,7 @@ def generate_single_quantile_plots(
         # Create plots for each configured output
         for output_config in plots_config.quantiles.outputs:
             output_name = f"quantiles_{location}_{output_config.type.value}"
+            logger.info("    Creating %s plot for %s", output_config.type.value, location)
 
             try:
                 # Determine which data to use and apply per-output filtering
@@ -645,6 +653,8 @@ def generate_quantile_grid_plot(
     if not plots_config.quantiles.grid:
         return
 
+    logger.info("Generating grid quantile plots for %d locations", len(calibrations))
+
     # Load surveillance data once before loop if any output needs it
     surveillance_data = {}
     needs_surveillance = any(output.show_surveillance for output in plots_config.quantiles.outputs)
@@ -728,11 +738,17 @@ def generate_quantile_grid_plot(
             # Prepare surveillance data for this output's specified source
             location_surveillance_for_output = {}
             surveillance_start_dates = {}
-            if output_config.show_surveillance and surveillance_source_name and surveillance_source_name in surveillance_data:
+            if (
+                output_config.show_surveillance
+                and surveillance_source_name
+                and surveillance_source_name in surveillance_data
+            ):
                 source = surveillance_data[surveillance_source_name]
                 surveillance_df = source["data"]
                 surveillance_config = source["config"]
-                logger.info(f"Loading surveillance from source '{surveillance_source_name}' for {output_type_name} output")
+                logger.info(
+                    f"Loading surveillance from source '{surveillance_source_name}' for {output_type_name} output"
+                )
                 logger.debug(f"Surveillance data shape: {surveillance_df.shape}")
 
                 for loc in location_proj_quants_raw.keys():
@@ -743,7 +759,9 @@ def generate_quantile_grid_plot(
                     df_surv_full, df_surv_filtered, surveillance_start_date = _prepare_surveillance_for_location(
                         surveillance_df, loc, proj_quant_raw, cal_quant, surveillance_config
                     )
-                    logger.debug(f"Location {loc}: surv_full={df_surv_full.shape if df_surv_full is not None else None}, surv_filtered={df_surv_filtered.shape if df_surv_filtered is not None else None}")
+                    logger.debug(
+                        f"Location {loc}: surv_full={df_surv_full.shape if df_surv_full is not None else None}, surv_filtered={df_surv_filtered.shape if df_surv_filtered is not None else None}"
+                    )
 
                     # Use the appropriate surveillance data based on output type
                     if output_type_name == "filtered":
@@ -767,7 +785,9 @@ def generate_quantile_grid_plot(
                 # Use the appropriate projection data based on output type
                 if output_type_name == "filtered":
                     if proj_quant_filtered is not None:
-                        location_proj_quants_for_output[loc] = _rename_value_column(proj_quant_filtered, "hospitalizations")
+                        location_proj_quants_for_output[loc] = _rename_value_column(
+                            proj_quant_filtered, "hospitalizations"
+                        )
                 elif output_type_name == "full":
                     if proj_quant_full is not None:
                         location_proj_quants_for_output[loc] = _rename_value_column(proj_quant_full, "hospitalizations")
@@ -815,6 +835,7 @@ def generate_quantile_grid_plot(
 
             # Generate grid plot based on output type
             if output_type_name in ["filtered", "full"]:
+                logger.info("    Creating %s grid plot", output_type_name)
                 try:
                     fig, axes = plot_calibration_projection_grid(
                         location_calibration_quantiles=(
@@ -854,6 +875,7 @@ def generate_quantile_grid_plot(
             elif output_type_name == "side_by_side":
                 # Side-by-side grid plot
                 # Grid layout: each location gets 2 panels (full + filtered)
+                logger.info("    Creating side_by_side grid plot")
                 try:
                     # Prepare surveillance and projection data for both full and filtered panels
                     location_surveillance_full_sbs = {}
@@ -871,8 +893,10 @@ def generate_quantile_grid_plot(
                             cal_quant = location_cal_quants.get(loc)
                             proj_quant_raw = location_proj_quants_raw.get(loc)
 
-                            df_surv_full, df_surv_filtered, surveillance_start_date = _prepare_surveillance_for_location(
-                                surveillance_df, loc, proj_quant_raw, cal_quant, surveillance_config
+                            df_surv_full, df_surv_filtered, surveillance_start_date = (
+                                _prepare_surveillance_for_location(
+                                    surveillance_df, loc, proj_quant_raw, cal_quant, surveillance_config
+                                )
                             )
 
                             if df_surv_full is not None:
@@ -889,9 +913,13 @@ def generate_quantile_grid_plot(
                             proj_quant_raw, surveillance_start_date, plots_config
                         )
                         if proj_quant_full is not None:
-                            location_proj_quants_full_sbs[loc] = _rename_value_column(proj_quant_full, "hospitalizations")
+                            location_proj_quants_full_sbs[loc] = _rename_value_column(
+                                proj_quant_full, "hospitalizations"
+                            )
                         if proj_quant_filtered is not None:
-                            location_proj_quants_filtered_sbs[loc] = _rename_value_column(proj_quant_filtered, "hospitalizations")
+                            location_proj_quants_filtered_sbs[loc] = _rename_value_column(
+                                proj_quant_filtered, "hospitalizations"
+                            )
 
                     # Get all locations
                     locations = set()
@@ -1070,6 +1098,7 @@ def generate_single_location_posterior_plots(
         return
 
     locations = get_locations_to_plot(calibrations, plots_config.posterior.single)
+    logger.info("Generating single-location posterior plots for %d locations", len(locations))
 
     # Generate plots for each location
     for calibration in calibrations:
@@ -1077,6 +1106,7 @@ def generate_single_location_posterior_plots(
             continue
 
         location = calibration.population
+        logger.info("    Creating posterior plot for %s", location)
 
         try:
             posterior_df = calibration.results.get_posterior_distribution()
@@ -1165,6 +1195,8 @@ def generate_posterior_grid_plot(
     """
     if not plots_config.posterior.grid:
         return
+
+    logger.info("Generating grid posterior plot for %d locations", len(calibrations))
 
     location_posteriors = {}
     all_params = set()

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -732,14 +732,18 @@ def generate_quantile_grid_plot(
                 source = surveillance_data[surveillance_source_name]
                 surveillance_df = source["data"]
                 surveillance_config = source["config"]
+                logger.info(f"Loading surveillance from source '{surveillance_source_name}' for {output_type_name} output")
+                logger.debug(f"Surveillance data shape: {surveillance_df.shape}")
 
                 for loc in location_proj_quants_raw.keys():
                     cal_quant = location_cal_quants.get(loc)
                     proj_quant_raw = location_proj_quants_raw.get(loc)
 
+                    logger.debug(f"Preparing surveillance for location: {loc}")
                     df_surv_full, df_surv_filtered, surveillance_start_date = _prepare_surveillance_for_location(
                         surveillance_df, loc, proj_quant_raw, cal_quant, surveillance_config
                     )
+                    logger.debug(f"Location {loc}: surv_full={df_surv_full.shape if df_surv_full is not None else None}, surv_filtered={df_surv_filtered.shape if df_surv_filtered is not None else None}")
 
                     # Use the appropriate surveillance data based on output type
                     if output_type_name == "filtered":

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -384,11 +384,8 @@ def generate_single_quantile_plots(
                     }
                 )[["date", "value"]]
 
-                # Filter to most recent N points if surveillance_points is set
-                if plots_config.quantiles.surveillance.surveillance_points is not None:
-                    df_surv_filtered = df_surv_filtered.sort_values("date").tail(
-                        plots_config.quantiles.surveillance.surveillance_points
-                    )
+                # Note: Per-output surveillance_points filtering will be applied later
+                # when generating each output, not here
 
                 # Get first surveillance date for projection filtering
                 if not df_surv_filtered.empty:
@@ -443,12 +440,39 @@ def generate_single_quantile_plots(
             output_name = f"quantiles_{location}_{output_config.type.value}"
 
             try:
+                # Determine which data to use and apply per-output filtering
+                if output_config.type == QuantilesOutputTypeEnum.FILTERED:
+                    proj_to_use = proj_quant_filtered
+                    surv_to_use = df_surv_filtered
+                elif output_config.type == QuantilesOutputTypeEnum.FULL:
+                    proj_to_use = proj_quant_full
+                    surv_to_use = df_surv_full
+                elif output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
+                    # Side-by-side handled separately below
+                    proj_to_use = None
+                    surv_to_use = None
+                else:
+                    logger.warning("Unknown output type %s for %s", output_config.type, location)
+                    continue
+
+                # Apply per-output surveillance_points filtering if needed (for filtered/full types)
+                if surv_to_use is not None and output_config.surveillance_points is not None:
+                    surv_to_use = surv_to_use.sort_values("date").tail(output_config.surveillance_points)
+
+                # Apply per-output horizon_max if specified (overrides base config)
+                if proj_to_use is not None and output_config.horizon_max is not None:
+                    from datetime import timedelta
+                    proj_dates = pd.to_datetime(proj_to_use["date"]).dt.date
+                    horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
+                    proj_to_use = proj_to_use[proj_dates.values <= horizon_end]
+
+                # Create the plot
                 if output_config.type == QuantilesOutputTypeEnum.FILTERED:
                     fig, ax = _create_filtered_plot(
                         location,
                         cal_quant,
-                        proj_quant_filtered,
-                        df_surv_filtered,
+                        proj_to_use,
+                        surv_to_use,
                         fitting_window_start,
                         fitting_window_end,
                         plots_config,
@@ -459,8 +483,8 @@ def generate_single_quantile_plots(
                     fig, ax = _create_full_plot(
                         location,
                         cal_quant,
-                        proj_quant_full,
-                        df_surv_full,
+                        proj_to_use,
+                        surv_to_use,
                         fitting_window_start,
                         fitting_window_end,
                         plots_config,
@@ -661,13 +685,8 @@ def generate_quantile_grid_plot(
                     }
                 )[["date", "value"]]
 
-                # Filter to most recent N points if surveillance_points is set
-                if plots_config.quantiles.surveillance.surveillance_points is not None:
-                    location_surveillance_filtered[loc] = (
-                        location_surveillance_filtered[loc]
-                        .sort_values("date")
-                        .tail(plots_config.quantiles.surveillance.surveillance_points)
-                    )
+                # Note: Per-output surveillance_points filtering will be applied later
+                # when generating each output, not here
 
                 # Get first surveillance date for projection filtering
                 if not location_surveillance_filtered[loc].empty:
@@ -727,171 +746,184 @@ def generate_quantile_grid_plot(
 
         value_col = "value"
 
-        # Create filtered grid plot
-        try:
-            fig, axes = plot_calibration_projection_grid(
-                location_calibration_quantiles=location_cal_quants if location_cal_quants else None,
-                location_projection_quantiles=location_proj_quants_filtered if location_proj_quants_filtered else None,
-                value_col=value_col,
-                calibration_color=plots_config.quantiles.calibration.color,
-                projection_color=plots_config.quantiles.projection.color,
-                location_surveillance=location_surveillance_filtered if location_surveillance_filtered else None,
-                location_fitting_window_starts=(
-                    location_fitting_window_starts if plots_config.quantiles.fitting_window_line.show else None
-                ),
-                location_fitting_window_ends=(
-                    location_fitting_window_ends if plots_config.quantiles.fitting_window_line.show else None
-                ),
-                panels_per_row=plots_config.quantiles.grid.panels_per_row,
-            )
+        # Loop over configured outputs and generate plots
+        for output_config in plots_config.quantiles.outputs:
+            output_type_name = output_config.type.value  # "filtered", "full", or "side_by_side"
 
-            # Package output
-            output_objs = []
-            for output_type in plots_config.figure_output_types:
-                output_objs.append(
-                    figure_to_output_object(fig, "quantiles_grid_filtered", output_type, plots_config.dpi)
-                )
-            out_dict["quantiles_grid_filtered"] = output_objs
-            plt.close(fig)
-        except Exception as e:
-            logger.warning("Failed to create filtered quantile grid plot: %s", e)
+            # Determine which projection data to use based on output type
+            if output_type_name == "filtered":
+                proj_quants_to_use = location_proj_quants_filtered
+                surv_data_to_use = location_surveillance_filtered
+            elif output_type_name == "full":
+                proj_quants_to_use = location_proj_quants_full
+                surv_data_to_use = location_surveillance_full
+            elif output_type_name == "side_by_side":
+                # Side-by-side uses both, handled separately below
+                proj_quants_to_use = None
+                surv_data_to_use = None
+            else:
+                logger.warning(f"Unknown output type: {output_type_name}")
+                continue
 
-        # Create full grid plot
-        try:
-            fig, axes = plot_calibration_projection_grid(
-                location_calibration_quantiles=location_cal_quants if location_cal_quants else None,
-                location_projection_quantiles=location_proj_quants_full if location_proj_quants_full else None,
-                value_col=value_col,
-                calibration_color=plots_config.quantiles.calibration.color,
-                projection_color=plots_config.quantiles.projection.color,
-                location_surveillance=location_surveillance_full if location_surveillance_full else None,
-                location_fitting_window_starts=(
-                    location_fitting_window_starts if plots_config.quantiles.fitting_window_line.show else None
-                ),
-                location_fitting_window_ends=(
-                    location_fitting_window_ends if plots_config.quantiles.fitting_window_line.show else None
-                ),
-                panels_per_row=plots_config.quantiles.grid.panels_per_row,
-            )
-
-            # Package output
-            output_objs = []
-            for output_type in plots_config.figure_output_types:
-                output_objs.append(figure_to_output_object(fig, "quantiles_grid_full", output_type, plots_config.dpi))
-            out_dict["quantiles_grid_full"] = output_objs
-            plt.close(fig)
-        except Exception as e:
-            logger.warning("Failed to create full quantile grid plot: %s", e)
-
-        # Create side-by-side grid plot
-        # Grid layout: each location gets 2 panels (full + filtered)
-        # If panels_per_row=4, that's 2 location-pairs per row
-        try:
-            # Get all locations
-            locations = set()
-            if location_cal_quants:
-                locations.update(location_cal_quants.keys())
-            if location_proj_quants_full:
-                locations.update(location_proj_quants_full.keys())
-            if location_proj_quants_filtered:
-                locations.update(location_proj_quants_filtered.keys())
-            locations = sorted(locations)
-
-            if locations:
-                n_locations = len(locations)
-                panels_per_row = plots_config.quantiles.grid.panels_per_row
-                pairs_per_row = panels_per_row // 2  # Each location needs 2 panels
-                nrows = math.ceil(n_locations / pairs_per_row)
-                ncols = panels_per_row
-
-                figsize = (4 * ncols, 3.6 * nrows)
-                fig, axes = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
-
-                for i, location in enumerate(locations):
-                    pair_idx = i  # Which location-pair (0, 1, 2, ...)
-                    row = pair_idx // pairs_per_row
-                    col_start = (pair_idx % pairs_per_row) * 2  # 0, 2, 4, ...
-
-                    ax_full = axes[row, col_start]  # Left panel of pair
-                    ax_filtered = axes[row, col_start + 1]  # Right panel of pair
-
-                    cal_quant = location_cal_quants.get(location) if location_cal_quants else None
-                    proj_quant_full = location_proj_quants_full.get(location) if location_proj_quants_full else None
-                    proj_quant_filtered = (
-                        location_proj_quants_filtered.get(location) if location_proj_quants_filtered else None
+            # Apply per-output surveillance_points filtering if needed
+            if surv_data_to_use and output_config.surveillance_points is not None:
+                surv_data_filtered_by_output = {}
+                for loc, surv_df in surv_data_to_use.items():
+                    surv_data_filtered_by_output[loc] = (
+                        surv_df.sort_values("date").tail(output_config.surveillance_points)
                     )
-                    surv_full = location_surveillance_full.get(location) if location_surveillance_full else None
-                    surv_filtered = (
-                        location_surveillance_filtered.get(location) if location_surveillance_filtered else None
-                    )
-                    fitting_window_start = (
-                        location_fitting_window_starts.get(location) if location_fitting_window_starts else None
-                    )
-                    fitting_window_end = (
-                        location_fitting_window_ends.get(location) if location_fitting_window_ends else None
-                    )
+                surv_data_to_use = surv_data_filtered_by_output
 
-                    # Left panel: Full
-                    plot_calibration_projection(
-                        calibration_quantiles=cal_quant,
-                        projection_quantiles=proj_quant_full,
+            # Apply per-output horizon_max if specified (overrides base config)
+            if proj_quants_to_use and output_config.horizon_max is not None:
+                from datetime import timedelta
+                proj_quants_horizon_filtered = {}
+                for loc, proj_df in proj_quants_to_use.items():
+                    proj_df_copy = proj_df.copy()
+                    proj_dates = pd.to_datetime(proj_df_copy["date"]).dt.date
+                    horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
+                    proj_quants_horizon_filtered[loc] = proj_df_copy[proj_dates.values <= horizon_end]
+                proj_quants_to_use = proj_quants_horizon_filtered
+
+            # Generate grid plot based on output type
+            if output_type_name in ["filtered", "full"]:
+                try:
+                    fig, axes = plot_calibration_projection_grid(
+                        location_calibration_quantiles=(
+                            location_cal_quants if output_config.show_calibration and location_cal_quants else None
+                        ),
+                        location_projection_quantiles=(
+                            proj_quants_to_use if output_config.show_projection and proj_quants_to_use else None
+                        ),
                         value_col=value_col,
                         calibration_color=plots_config.quantiles.calibration.color,
                         projection_color=plots_config.quantiles.projection.color,
-                        df_surveillance=surv_full,
-                        fitting_window_start=(
-                            fitting_window_start if plots_config.quantiles.fitting_window_line.show else None
+                        location_surveillance=(
+                            surv_data_to_use if output_config.show_surveillance and surv_data_to_use else None
                         ),
-                        fitting_window_end=(
-                            fitting_window_end if plots_config.quantiles.fitting_window_line.show else None
+                        location_fitting_window_starts=(
+                            location_fitting_window_starts if output_config.show_fitting_window_line else None
                         ),
-                        title=f"{_format_location_name(location)} - Full",
-                        ax=ax_full,
+                        location_fitting_window_ends=(
+                            location_fitting_window_ends if output_config.show_fitting_window_line else None
+                        ),
+                        panels_per_row=plots_config.quantiles.grid.panels_per_row,
                     )
 
-                    # Right panel: Filtered
-                    plot_calibration_projection(
-                        calibration_quantiles=cal_quant,
-                        projection_quantiles=proj_quant_filtered,
-                        value_col=value_col,
-                        calibration_color=plots_config.quantiles.calibration.color,
-                        projection_color=plots_config.quantiles.projection.color,
-                        df_surveillance=surv_filtered,
-                        fitting_window_start=(
-                            fitting_window_start if plots_config.quantiles.fitting_window_line.show else None
-                        ),
-                        fitting_window_end=(
-                            fitting_window_end if plots_config.quantiles.fitting_window_line.show else None
-                        ),
-                        title=f"{_format_location_name(location)} - Filtered",
-                        ax=ax_filtered,
-                    )
+                    # Package output
+                    output_objs = []
+                    for fig_output_type in plots_config.figure_output_types:
+                        output_objs.append(
+                            figure_to_output_object(
+                                fig, f"quantiles_grid_{output_type_name}", fig_output_type, plots_config.dpi
+                            )
+                        )
+                    out_dict[f"quantiles_grid_{output_type_name}"] = output_objs
+                    plt.close(fig)
+                except Exception as e:
+                    logger.warning(f"Failed to create {output_type_name} quantile grid plot: %s", e)
 
-                    # Hide legends except for first pair
-                    if i != 0:
-                        for ax in [ax_full, ax_filtered]:
-                            legend = ax.get_legend()
-                            if legend is not None:
-                                legend.remove()
+            elif output_type_name == "side_by_side":
+                # Side-by-side grid plot
+                # Grid layout: each location gets 2 panels (full + filtered)
+                try:
+                    # Get all locations
+                    locations = set()
+                    if location_cal_quants:
+                        locations.update(location_cal_quants.keys())
+                    if location_proj_quants_full:
+                        locations.update(location_proj_quants_full.keys())
+                    if location_proj_quants_filtered:
+                        locations.update(location_proj_quants_filtered.keys())
+                    locations = sorted(locations)
 
-                # Remove unused axes
-                for idx in range(n_locations * 2, nrows * ncols):
-                    r = idx // ncols
-                    c = idx % ncols
-                    axes[r, c].axis("off")
+                    if locations:
+                        n_locations = len(locations)
+                        panels_per_row = output_config.columns if hasattr(output_config, 'columns') else plots_config.quantiles.grid.panels_per_row
+                        pairs_per_row = panels_per_row // 2  # Each location needs 2 panels
+                        nrows = math.ceil(n_locations / pairs_per_row)
+                        ncols = panels_per_row
 
-                plt.tight_layout()
+                        figsize = output_config.figsize if output_config.figsize else (4 * ncols, 3.6 * nrows)
+                        fig, axes = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
 
-                # Package output
-                output_objs = []
-                for output_type in plots_config.figure_output_types:
-                    output_objs.append(
-                        figure_to_output_object(fig, "quantiles_grid_sidebyside", output_type, plots_config.dpi)
-                    )
-                out_dict["quantiles_grid_sidebyside"] = output_objs
-                plt.close(fig)
-        except Exception as e:
-            logger.warning("Failed to create sidebyside quantile grid plot: %s", e)
+                        for i, location in enumerate(locations):
+                            pair_idx = i  # Which location-pair (0, 1, 2, ...)
+                            row = pair_idx // pairs_per_row
+                            col_start = (pair_idx % pairs_per_row) * 2  # 0, 2, 4, ...
+
+                            ax_full = axes[row, col_start]  # Left panel of pair
+                            ax_filtered = axes[row, col_start + 1]  # Right panel of pair
+
+                            cal_quant = location_cal_quants.get(location) if output_config.show_calibration and location_cal_quants else None
+                            proj_quant_full = location_proj_quants_full.get(location) if output_config.show_projection and location_proj_quants_full else None
+                            proj_quant_filtered = (
+                                location_proj_quants_filtered.get(location) if output_config.show_projection and location_proj_quants_filtered else None
+                            )
+                            surv_full = location_surveillance_full.get(location) if output_config.show_surveillance and location_surveillance_full else None
+                            surv_filtered = (
+                                location_surveillance_filtered.get(location) if output_config.show_surveillance and location_surveillance_filtered else None
+                            )
+                            fitting_window_start = (
+                                location_fitting_window_starts.get(location) if output_config.show_fitting_window_line and location_fitting_window_starts else None
+                            )
+                            fitting_window_end = (
+                                location_fitting_window_ends.get(location) if output_config.show_fitting_window_line and location_fitting_window_ends else None
+                            )
+
+                            # Left panel: Full
+                            plot_calibration_projection(
+                                calibration_quantiles=cal_quant,
+                                projection_quantiles=proj_quant_full,
+                                value_col=value_col,
+                                calibration_color=plots_config.quantiles.calibration.color,
+                                projection_color=plots_config.quantiles.projection.color,
+                                df_surveillance=surv_full,
+                                fitting_window_start=fitting_window_start,
+                                fitting_window_end=fitting_window_end,
+                                title=f"{_format_location_name(location)} - Full",
+                                ax=ax_full,
+                            )
+
+                            # Right panel: Filtered
+                            plot_calibration_projection(
+                                calibration_quantiles=cal_quant,
+                                projection_quantiles=proj_quant_filtered,
+                                value_col=value_col,
+                                calibration_color=plots_config.quantiles.calibration.color,
+                                projection_color=plots_config.quantiles.projection.color,
+                                df_surveillance=surv_filtered,
+                                fitting_window_start=fitting_window_start,
+                                fitting_window_end=fitting_window_end,
+                                title=f"{_format_location_name(location)} - Filtered",
+                                ax=ax_filtered,
+                            )
+
+                            # Hide legends except for first pair
+                            if i != 0:
+                                for ax in [ax_full, ax_filtered]:
+                                    legend = ax.get_legend()
+                                    if legend is not None:
+                                        legend.remove()
+
+                        # Remove unused axes
+                        for idx in range(n_locations * 2, nrows * ncols):
+                            r = idx // ncols
+                            c = idx % ncols
+                            axes[r, c].axis("off")
+
+                        plt.tight_layout()
+
+                        # Package output
+                        output_objs = []
+                        for fig_output_type in plots_config.figure_output_types:
+                            output_objs.append(
+                                figure_to_output_object(fig, "quantiles_grid_sidebyside", fig_output_type, plots_config.dpi)
+                            )
+                        out_dict["quantiles_grid_sidebyside"] = output_objs
+                        plt.close(fig)
+                except Exception as e:
+                    logger.warning(f"Failed to create sidebyside quantile grid plot: {e}")
 
 
 def generate_single_location_posterior_plots(

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -7,13 +7,14 @@ outputs as OutputObject instances.
 
 import logging
 import math
+from datetime import date, timedelta
 
 import matplotlib.pyplot as plt
 import pandas as pd
 
 from ..builders.utils import get_data_in_location
 from ..schema.dispatcher import CalibrationOutput
-from ..schema.output import OutputObject, PlotsConfig
+from ..schema.output import OutputObject, PlotsConfig, QuantilesOutputConfig, QuantilesOutputTypeEnum
 from .core import (
     _format_location_name,
     figure_to_output_object,
@@ -27,6 +28,184 @@ from .core import (
 logger = logging.getLogger(__name__)
 
 
+def _fetch_quantiles_for_location(
+    calibration: CalibrationOutput,
+    plots_config: PlotsConfig,
+    needs_calibration: bool,
+    needs_projection: bool,
+) -> tuple[pd.DataFrame | None, pd.DataFrame | None]:
+    """
+    Fetch calibration and projection quantiles for a single location.
+
+    Parameters
+    ----------
+    calibration : CalibrationOutput
+        Calibration results for one location.
+    plots_config : PlotsConfig
+        Plot configuration with quantile levels.
+    needs_calibration : bool
+        Whether calibration quantiles are requested.
+    needs_projection : bool
+        Whether projection quantiles are requested.
+
+    Returns
+    -------
+    tuple
+        (cal_quant, proj_quant) where either can be None if not requested or retrieval fails.
+    """
+    cal_quant = None
+    if needs_calibration:
+        try:
+            cal_quant = calibration.results.get_calibration_quantiles(
+                quantiles=plots_config.quantiles.quantiles,
+                variables=["date", "data"],
+            )
+        except (ValueError, AttributeError, TypeError, IndexError) as e:
+            logger.warning("Failed to get calibration quantiles for %s: %s", calibration.population, e)
+
+    proj_quant = None
+    if needs_projection:
+        try:
+            proj_quant = calibration.results.get_projection_quantiles(
+                quantiles=plots_config.quantiles.quantiles,
+            )
+        except (ValueError, AttributeError, TypeError, IndexError) as e:
+            logger.warning("Failed to get projection quantiles for %s: %s", calibration.population, e)
+
+    return cal_quant, proj_quant
+
+
+def _prepare_surveillance_for_location(
+    surveillance: pd.DataFrame | None,
+    location: str,
+    proj_quant: pd.DataFrame | None,
+    cal_quant: pd.DataFrame | None,
+    plots_config: PlotsConfig,
+) -> tuple[pd.DataFrame | None, pd.DataFrame | None, date | None]:
+    """
+    Build full and filtered surveillance dataframes for a location.
+
+    Parameters
+    ----------
+    surveillance : pd.DataFrame or None
+        Raw surveillance data for all locations.
+    location : str
+        Location identifier to filter surveillance.
+    proj_quant : pd.DataFrame or None
+        Projection quantiles for the location (preferred to infer timespan start).
+    cal_quant : pd.DataFrame or None
+        Calibration quantiles for the location (fallback to infer timespan start).
+    plots_config : PlotsConfig
+        Plot configuration for surveillance column names.
+
+    Returns
+    -------
+    tuple
+        (df_surv_full, df_surv_filtered, surveillance_start_date) where start date is the first filtered point.
+    """
+    df_surv_full = None
+    df_surv_filtered = None
+    surveillance_start_date = None
+
+    if surveillance is None or not plots_config.quantiles.surveillance.location_column:
+        return df_surv_full, df_surv_filtered, surveillance_start_date
+
+    surv = get_data_in_location(surveillance, location, plots_config.quantiles.surveillance.location_column)
+    date_col = plots_config.quantiles.surveillance.date_column
+    value_col = plots_config.quantiles.surveillance.value_column
+
+    # Full surveillance (no filtering)
+    if not surv.empty and date_col and value_col:
+        df_surv_full = surv.rename(columns={date_col: "date", value_col: "value"})[["date", "value"]]
+
+    # Filtered surveillance
+    surv_filtered = surv.copy()
+
+    if not surv_filtered.empty and date_col:
+        # Align surveillance window with available quantiles
+        quantiles_for_timespan = proj_quant if proj_quant is not None else cal_quant
+        if quantiles_for_timespan is not None and "date" in quantiles_for_timespan.columns:
+            timespan_start = pd.to_datetime(quantiles_for_timespan["date"]).min().date()
+            surv_filtered = surv_filtered[
+                pd.to_datetime(surv_filtered[date_col]).dt.date >= timespan_start
+            ]
+
+    if not surv_filtered.empty and date_col and value_col:
+        df_surv_filtered = surv_filtered.rename(columns={date_col: "date", value_col: "value"})[["date", "value"]]
+
+        if not df_surv_filtered.empty:
+            surveillance_start_date = pd.to_datetime(df_surv_filtered["date"]).min().date()
+
+    return df_surv_full, df_surv_filtered, surveillance_start_date
+
+
+def _prepare_projection_quantiles(
+    proj_quant: pd.DataFrame | None,
+    surveillance_start_date: date | None,
+    plots_config: PlotsConfig,
+) -> tuple[pd.DataFrame | None, pd.DataFrame | None]:
+    """
+    Create full and filtered projection quantiles for a location.
+
+    Parameters
+    ----------
+    proj_quant : pd.DataFrame or None
+        Projection quantiles for the location.
+    surveillance_start_date : date or None
+        First surveillance date used to cut projections for the filtered version.
+    plots_config : PlotsConfig
+        Plot configuration providing reference_date and base horizon_max.
+
+    Returns
+    -------
+    tuple
+        (proj_quant_full, proj_quant_filtered) using base horizon_max; filtered also cuts before surveillance start.
+    """
+    proj_quant_full = None
+    proj_quant_filtered = None
+
+    if proj_quant is None:
+        return proj_quant_full, proj_quant_filtered
+
+    # Full version: horizon_max only
+    proj_quant_full = proj_quant.copy()
+    if plots_config.quantiles.horizon_max is not None:
+        proj_dates_full = pd.to_datetime(proj_quant_full["date"]).dt.date
+        horizon_end_full = plots_config.reference_date + timedelta(weeks=plots_config.quantiles.horizon_max)
+        proj_quant_full = proj_quant_full[proj_dates_full.values <= horizon_end_full]
+
+    # Filtered version: surveillance start + horizon_max
+    proj_quant_filtered = proj_quant.copy()
+    proj_dates = pd.to_datetime(proj_quant_filtered["date"]).dt.date
+    if surveillance_start_date is not None:
+        proj_start = proj_dates.min()
+        if proj_start < surveillance_start_date:
+            proj_quant_filtered = proj_quant_filtered[proj_dates.values >= surveillance_start_date]
+
+    if plots_config.quantiles.horizon_max is not None:
+        proj_dates = pd.to_datetime(proj_quant_filtered["date"]).dt.date
+        horizon_end = plots_config.reference_date + timedelta(weeks=plots_config.quantiles.horizon_max)
+        proj_quant_filtered = proj_quant_filtered[proj_dates.values <= horizon_end]
+
+    return proj_quant_full, proj_quant_filtered
+
+
+def _rename_value_column(df: pd.DataFrame | None, old_name: str) -> pd.DataFrame | None:
+    """
+    Return a copy with `old_name` renamed to `value` if the column exists; otherwise return df unchanged.
+
+    Parameters
+    ----------
+    df : pd.DataFrame or None
+        Dataframe to inspect and rename.
+    old_name : str
+        Column name to replace with `value`.
+    """
+    if df is not None and old_name in df.columns:
+        return df.rename(columns={old_name: "value"})
+    return df
+
+
 def _create_filtered_plot(
     location: str,
     cal_quant: pd.DataFrame | None,
@@ -36,7 +215,7 @@ def _create_filtered_plot(
     fitting_window_end: pd.Timestamp | None,
     plots_config: PlotsConfig,
     value_col: str,
-    output_config,
+    output_config: QuantilesOutputConfig,
 ) -> tuple:
     """
     Create filtered quantile plot for a location.
@@ -89,7 +268,7 @@ def _create_full_plot(
     fitting_window_end: pd.Timestamp | None,
     plots_config: PlotsConfig,
     value_col: str,
-    output_config,
+    output_config: QuantilesOutputConfig,
 ) -> tuple:
     """
     Create full quantile plot for a location.
@@ -144,7 +323,7 @@ def _create_sidebyside_plot(
     fitting_window_end: pd.Timestamp | None,
     plots_config: PlotsConfig,
     value_col: str,
-    output_config,
+    output_config: QuantilesOutputConfig,
 ) -> tuple:
     """
     Create side-by-side (full | filtered) quantile plot for a location.
@@ -264,6 +443,10 @@ def generate_single_quantile_plots(
                 "Failed to load surveillance data from %s: %s", plots_config.quantiles.surveillance.data_path, e
             )
 
+    needs_calibration = any(output.show_calibration for output in plots_config.quantiles.outputs)
+    needs_projection = any(output.show_projection for output in plots_config.quantiles.outputs)
+    needs_fitting_window = any(output.show_fitting_window_line for output in plots_config.quantiles.outputs)
+
     # Generate plots for each location
     for calibration in calibrations:
         # Skip locations not in config
@@ -275,230 +458,103 @@ def generate_single_quantile_plots(
         # calibration.results = filter_failed_calibration_trajectories(calibration.results)
         calibration.results = filter_failed_projections(calibration.results)
 
-        # Get pre-computed quantiles
-
-        # Check if any output needs calibration/projection/fitting window
-        needs_calibration = any(output.show_calibration for output in plots_config.quantiles.outputs)
-        needs_projection = any(output.show_projection for output in plots_config.quantiles.outputs)
-        needs_fitting_window = any(output.show_fitting_window_line for output in plots_config.quantiles.outputs)
-
-        # Calibration quantiles
-        cal_quant = None
-        if needs_calibration:
-            try:
-                cal_quant = calibration.results.get_calibration_quantiles(
-                    quantiles=plots_config.quantiles.quantiles,
-                    variables=["date", "data"],
-                )
-            except (ValueError, AttributeError, TypeError) as e:
-                logger.warning(
-                    "Failed to get calibration quantiles for %s: %s",
-                    location,
-                    e,
-                )
+        cal_quant, proj_quant = _fetch_quantiles_for_location(
+            calibration, plots_config, needs_calibration, needs_projection
+        )
 
         # Calculate fitting window start and end from calibration quantiles
         fitting_window_start = None
         fitting_window_end = None
-        if needs_fitting_window:
-            # Fetch calibration quantiles for fitting window calculation even if not displaying them
-            cal_quant_for_fitting = cal_quant
-            if cal_quant_for_fitting is None:
-                try:
-                    cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
-                        quantiles=[0.5],  # Only need one quantile to get dates
-                        variables=["date", "data"],
-                    )
-                except (ValueError, AttributeError, TypeError) as e:
-                    logger.warning(
-                        "Failed to get calibration quantiles for fitting window for %s: %s",
-                        location,
-                        e,
-                    )
-
-            if cal_quant_for_fitting is not None and "date" in cal_quant_for_fitting.columns:
-                dates = pd.to_datetime(cal_quant_for_fitting["date"]).dt.date
-                fitting_window_start = dates.min()
-                fitting_window_end = dates.max()
-
-        # Projection quantiles
-        # TODO: "hospitalizations" column is hardcoded in projection quantiles
-        proj_quant = None
-        if needs_projection:
+    if needs_fitting_window:
+        cal_quant_for_fitting = cal_quant
+        if cal_quant_for_fitting is None:
             try:
-                proj_quant = calibration.results.get_projection_quantiles(
-                    quantiles=plots_config.quantiles.quantiles,
+                cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
+                    quantiles=[0.5],  # Only need one quantile to get dates
+                    variables=["date", "data"],
                 )
-            except (ValueError, AttributeError) as e:
+            except (ValueError, AttributeError, TypeError) as e:
                 logger.warning(
-                    "Failed to get projection quantiles for %s: %s",
+                    "Failed to get calibration quantiles for fitting window for %s: %s",
                     location,
                     e,
                 )
 
-        # Prepare surveillance data for this location
-        df_surv_full = None  # Full surveillance data (no filtering)
-        df_surv_filtered = None  # Filtered surveillance data
-        surveillance_start_date = None
-        if surveillance is not None and plots_config.quantiles.surveillance.location_column:
-            surv = get_data_in_location(surveillance, location, plots_config.quantiles.surveillance.location_column)
+        if cal_quant_for_fitting is not None and "date" in cal_quant_for_fitting.columns:
+            # Use calibration dates to mark fitting window on plots
+            dates = pd.to_datetime(cal_quant_for_fitting["date"]).dt.date
+            fitting_window_start = dates.min()
+            fitting_window_end = dates.max()
 
-            # Create full surveillance dataframe (no filtering)
-            if (
-                not surv.empty
-                and plots_config.quantiles.surveillance.date_column
-                and plots_config.quantiles.surveillance.value_column
-            ):
-                df_surv_full = surv.rename(
-                    columns={
-                        plots_config.quantiles.surveillance.date_column: "date",
-                        plots_config.quantiles.surveillance.value_column: "value",
-                    }
-                )[["date", "value"]]
+        df_surv_full, df_surv_filtered, surveillance_start_date = _prepare_surveillance_for_location(
+            surveillance, location, proj_quant, cal_quant, plots_config
+        )
 
-            # Create filtered surveillance dataframe
-            surv_filtered = surv.copy()
-
-            # Filter surveillance data to start from timespan start (inferred from projection or calibration quantiles)
-            if not surv_filtered.empty:
-                # Use projection quantiles to get full timespan, fall back to calibration if not available
-                quantiles_for_timespan = proj_quant if proj_quant is not None else cal_quant
-                if quantiles_for_timespan is not None and "date" in quantiles_for_timespan.columns:
-                    # Infer timespan start from the earliest date in quantiles
-                    timespan_start = pd.to_datetime(quantiles_for_timespan["date"]).min().date()
-                    # Filter surveillance data to start from timespan start
-                    surv_filtered = surv_filtered[
-                        pd.to_datetime(surv_filtered[plots_config.quantiles.surveillance.date_column]).dt.date
-                        >= timespan_start
-                    ]
-
-            if (
-                not surv_filtered.empty
-                and plots_config.quantiles.surveillance.date_column
-                and plots_config.quantiles.surveillance.value_column
-            ):
-                df_surv_filtered = surv_filtered.rename(
-                    columns={
-                        plots_config.quantiles.surveillance.date_column: "date",
-                        plots_config.quantiles.surveillance.value_column: "value",
-                    }
-                )[["date", "value"]]
-
-                # Note: Per-output surveillance_points filtering will be applied later
-                # when generating each output, not here
-
-                # Get first surveillance date for projection filtering
-                if not df_surv_filtered.empty:
-                    surveillance_start_date = pd.to_datetime(df_surv_filtered["date"]).min().date()
-
-        # Prepare projection quantiles - create both filtered and full versions
-        proj_quant_filtered = None
-        proj_quant_full = None
-
-        if proj_quant is not None:
-            from datetime import timedelta
-
-            # Full version: apply horizon_max only (no surveillance_start_date filtering)
-            proj_quant_full = proj_quant.copy()
-            if plots_config.quantiles.horizon_max is not None:
-                proj_dates_full = pd.to_datetime(proj_quant_full["date"]).dt.date
-                horizon_end_full = plots_config.reference_date + timedelta(weeks=plots_config.quantiles.horizon_max)
-                proj_quant_full = proj_quant_full[proj_dates_full.values <= horizon_end_full]
-
-            # Filtered version: apply standard filtering
-            proj_quant_filtered = proj_quant.copy()
-            proj_dates = pd.to_datetime(proj_quant_filtered["date"]).dt.date
-
-            # Start at first surveillance point if there's projection data before it
-            if surveillance_start_date is not None:
-                proj_start = proj_dates.min()
-                # Only filter if projection starts before first surveillance point
-                if proj_start < surveillance_start_date:
-                    proj_quant_filtered = proj_quant_filtered[proj_dates.values >= surveillance_start_date]
-
-            # End at horizon_max if specified
-            if plots_config.quantiles.horizon_max is not None:
-                horizon_end = plots_config.reference_date + timedelta(weeks=plots_config.quantiles.horizon_max)
-                proj_dates = pd.to_datetime(proj_quant_filtered["date"]).dt.date
-                proj_quant_filtered = proj_quant_filtered[proj_dates.values <= horizon_end]
+        proj_quant_full, proj_quant_filtered = _prepare_projection_quantiles(
+            proj_quant, surveillance_start_date, plots_config
+        )
 
         # Rename columns to have consistent naming for plotting
         # TODO: Calibration uses "data", projection uses "hospitalizations" - make this configurable
-        if cal_quant is not None and "data" in cal_quant.columns:
-            cal_quant = cal_quant.rename(columns={"data": "value"})
-        if proj_quant_filtered is not None and "hospitalizations" in proj_quant_filtered.columns:
-            proj_quant_filtered = proj_quant_filtered.rename(columns={"hospitalizations": "value"})
-        if proj_quant_full is not None and "hospitalizations" in proj_quant_full.columns:
-            proj_quant_full = proj_quant_full.rename(columns={"hospitalizations": "value"})
+        # Normalizing to "value" means the plotting primitives don't need to know source-specific names
+        cal_quant = _rename_value_column(cal_quant, "data")
+        proj_quant_filtered = _rename_value_column(proj_quant_filtered, "hospitalizations")
+        proj_quant_full = _rename_value_column(proj_quant_full, "hospitalizations")
 
         value_col = "value"
 
         # Create plots for each configured output
-        from ..schema.output import QuantilesOutputTypeEnum
-
         for output_config in plots_config.quantiles.outputs:
             output_name = f"quantiles_{location}_{output_config.type.value}"
 
             try:
-                # Determine which data to use and apply per-output filtering
-                if output_config.type == QuantilesOutputTypeEnum.FILTERED:
-                    proj_to_use = proj_quant_filtered
-                    surv_to_use = df_surv_filtered
-                elif output_config.type == QuantilesOutputTypeEnum.FULL:
-                    proj_to_use = proj_quant_full
-                    surv_to_use = df_surv_full
-                elif output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
-                    # Side-by-side handled separately below
-                    proj_to_use = None
-                    surv_to_use = None
-                else:
-                    logger.warning("Unknown output type %s for %s", output_config.type, location)
-                    continue
-
-                # Apply per-output surveillance_points filtering if needed (for filtered/full types)
-                if surv_to_use is not None and output_config.surveillance_points is not None:
-                    surv_to_use = surv_to_use.sort_values("date").tail(output_config.surveillance_points)
-
-                # Apply per-output horizon_max if specified (overrides base config)
-                if proj_to_use is not None and output_config.horizon_max is not None:
-                    from datetime import timedelta
-                    proj_dates = pd.to_datetime(proj_to_use["date"]).dt.date
-                    horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
-                    proj_to_use = proj_to_use[proj_dates.values <= horizon_end]
-
-                # Create the plot
-                if output_config.type == QuantilesOutputTypeEnum.FILTERED:
-                    fig, ax = _create_filtered_plot(
-                        location,
-                        cal_quant,
-                        proj_to_use,
-                        surv_to_use,
-                        fitting_window_start,
-                        fitting_window_end,
-                        plots_config,
-                        value_col,
-                        output_config,
+                if output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
+                    # Side-by-side needs per-panel copies so each panel can apply its own trims
+                    proj_quant_full_for_output = proj_quant_full.copy() if proj_quant_full is not None else None
+                    proj_quant_filtered_for_output = (
+                        proj_quant_filtered.copy() if proj_quant_filtered is not None else None
                     )
-                elif output_config.type == QuantilesOutputTypeEnum.FULL:
-                    fig, ax = _create_full_plot(
-                        location,
-                        cal_quant,
-                        proj_to_use,
-                        surv_to_use,
-                        fitting_window_start,
-                        fitting_window_end,
-                        plots_config,
-                        value_col,
-                        output_config,
-                    )
-                elif output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
+
+                    # Apply per-output horizon and surveillance trims on copies so base data stays reusable
+                    if output_config.horizon_max is not None:
+                        horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
+                        if proj_quant_full_for_output is not None:
+                            proj_dates = pd.to_datetime(proj_quant_full_for_output["date"]).dt.date
+                            proj_quant_full_for_output = proj_quant_full_for_output[proj_dates.values <= horizon_end]
+                        if proj_quant_filtered_for_output is not None:
+                            proj_dates = pd.to_datetime(proj_quant_filtered_for_output["date"]).dt.date
+                            proj_quant_filtered_for_output = proj_quant_filtered_for_output[
+                                proj_dates.values <= horizon_end
+                            ]
+
+                    surv_full = df_surv_full.copy() if df_surv_full is not None else None
+                    surv_filtered = df_surv_filtered.copy() if df_surv_filtered is not None else None
+
+                    if output_config.full_panel and surv_full is not None:
+                        if output_config.full_panel.surveillance_start_date is not None:
+                            start_date = pd.to_datetime(output_config.full_panel.surveillance_start_date).date()
+                            surv_dates = pd.to_datetime(surv_full["date"]).dt.date
+                            surv_full = surv_full[surv_dates >= start_date]
+                        elif output_config.full_panel.surveillance_points is not None:
+                            surv_full = surv_full.sort_values("date").tail(output_config.full_panel.surveillance_points)
+
+                    if output_config.filtered_panel and surv_filtered is not None:
+                        if output_config.filtered_panel.surveillance_start_date is not None:
+                            start_date = pd.to_datetime(output_config.filtered_panel.surveillance_start_date).date()
+                            surv_dates = pd.to_datetime(surv_filtered["date"]).dt.date
+                            surv_filtered = surv_filtered[surv_dates >= start_date]
+                        elif output_config.filtered_panel.surveillance_points is not None:
+                            surv_filtered = surv_filtered.sort_values("date").tail(
+                                output_config.filtered_panel.surveillance_points
+                            )
+
                     fig, (ax_full, ax_filtered) = _create_sidebyside_plot(
                         location,
                         cal_quant,
-                        proj_quant_full,
-                        proj_quant_filtered,
-                        df_surv_full,
-                        df_surv_filtered,
+                        proj_quant_full_for_output,
+                        proj_quant_filtered_for_output,
+                        surv_full,
+                        surv_filtered,
                         fitting_window_start,
                         fitting_window_end,
                         plots_config,
@@ -506,8 +562,62 @@ def generate_single_quantile_plots(
                         output_config,
                     )
                 else:
-                    logger.warning("Unknown output type %s for %s", output_config.type, location)
-                    continue
+                    # Determine which data to use and apply per-output filtering
+                    if output_config.type == QuantilesOutputTypeEnum.FILTERED:
+                        proj_to_use = proj_quant_filtered
+                        surv_to_use = df_surv_filtered
+                    elif output_config.type == QuantilesOutputTypeEnum.FULL:
+                        proj_to_use = proj_quant_full
+                        surv_to_use = df_surv_full
+                    else:
+                        logger.warning("Unknown output type %s for %s", output_config.type, location)
+                        continue
+
+                    # Apply per-output surveillance filtering if needed (for filtered/full types)
+                    if surv_to_use is not None:
+                        # Date-based filtering takes precedence over points-based filtering
+                        if output_config.surveillance_start_date is not None:
+                            start_date = pd.to_datetime(output_config.surveillance_start_date).date()
+                            surv_dates = pd.to_datetime(surv_to_use["date"]).dt.date
+                            surv_to_use = surv_to_use[surv_dates >= start_date]
+                        elif output_config.surveillance_points is not None:
+                            surv_to_use = surv_to_use.sort_values("date").tail(output_config.surveillance_points)
+
+                    # Apply per-output horizon_max if specified (overrides base config)
+                    if proj_to_use is not None and output_config.horizon_max is not None:
+                        # Per-output horizon can be tighter than the base config
+                        proj_dates = pd.to_datetime(proj_to_use["date"]).dt.date
+                        horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
+                        proj_to_use = proj_to_use[proj_dates.values <= horizon_end]
+
+                    # Create the plot
+                    if output_config.type == QuantilesOutputTypeEnum.FILTERED:
+                        fig, ax = _create_filtered_plot(
+                            location,
+                            cal_quant,
+                            proj_to_use,
+                            surv_to_use,
+                            fitting_window_start,
+                            fitting_window_end,
+                            plots_config,
+                            value_col,
+                            output_config,
+                        )
+                    elif output_config.type == QuantilesOutputTypeEnum.FULL:
+                        fig, ax = _create_full_plot(
+                            location,
+                            cal_quant,
+                            proj_to_use,
+                            surv_to_use,
+                            fitting_window_start,
+                            fitting_window_end,
+                            plots_config,
+                            value_col,
+                            output_config,
+                        )
+                    else:
+                        logger.warning("Unknown output type %s for %s", output_config.type, location)
+                        continue
 
                 # Package output
                 output_objs = []
@@ -563,6 +673,10 @@ def generate_quantile_grid_plot(
                 "Failed to load surveillance data from %s: %s", plots_config.quantiles.surveillance.data_path, e
             )
 
+    needs_calibration = any(output.show_calibration for output in plots_config.quantiles.outputs)
+    needs_projection = any(output.show_projection for output in plots_config.quantiles.outputs)
+    needs_fitting_window = any(output.show_fitting_window_line for output in plots_config.quantiles.outputs)
+
     # Collect quantiles and surveillance data for each location
     location_cal_quants = {}
     location_proj_quants_filtered = {}
@@ -580,26 +694,11 @@ def generate_quantile_grid_plot(
         # calibration.results = filter_failed_calibration_trajectories(calibration.results)
         calibration.results = filter_failed_projections(calibration.results)
 
-        # Get pre-computed quantiles
-
-        # Check if any output needs calibration/projection/fitting window
-        needs_calibration = any(output.show_calibration for output in plots_config.quantiles.outputs)
-        needs_projection = any(output.show_projection for output in plots_config.quantiles.outputs)
-        needs_fitting_window = any(output.show_fitting_window_line for output in plots_config.quantiles.outputs)
-
-        # Calibration quantiles
-        if needs_calibration:
-            try:
-                location_cal_quants[loc] = calibration.results.get_calibration_quantiles(
-                    quantiles=plots_config.quantiles.quantiles,
-                    variables=["date", "data"],
-                )
-            except (ValueError, AttributeError, TypeError, IndexError) as e:
-                logger.warning(
-                    "Failed to get calibration quantiles for %s: %s",
-                    loc,
-                    e,
-                )
+        cal_quant, proj_quant_raw = _fetch_quantiles_for_location(
+            calibration, plots_config, needs_calibration, needs_projection
+        )
+        if cal_quant is not None:
+            location_cal_quants[loc] = cal_quant
 
         # Calculate fitting window start and end from calibration quantiles
         if needs_fitting_window:
@@ -623,126 +722,34 @@ def generate_quantile_grid_plot(
                 location_fitting_window_starts[loc] = dates.min()
                 location_fitting_window_ends[loc] = dates.max()
 
-        # Projection quantiles
-        # TODO: "hospitalizations" column is hardcoded in projection quantiles
-        proj_quant_raw = None
-        if needs_projection:
-            try:
-                proj_quant_raw = calibration.results.get_projection_quantiles(
-                    quantiles=plots_config.quantiles.quantiles,
-                )
-            except (ValueError, AttributeError, TypeError, IndexError) as e:
-                logger.warning(
-                    "Failed to get projection quantiles for %s: %s",
-                    loc,
-                    e,
-                )
+        df_surv_full, df_surv_filtered, surveillance_start_date = _prepare_surveillance_for_location(
+            surveillance, loc, proj_quant_raw, cal_quant, plots_config
+        )
+        if df_surv_full is not None:
+            location_surveillance_full[loc] = df_surv_full
+        if df_surv_filtered is not None:
+            location_surveillance_filtered[loc] = df_surv_filtered
 
-        # Prepare surveillance data for this location
-        surveillance_start_date = None
-        if surveillance is not None and plots_config.quantiles.surveillance.location_column:
-            surv = get_data_in_location(surveillance, loc, plots_config.quantiles.surveillance.location_column)
-
-            # Create full surveillance dataframe (no filtering)
-            if (
-                not surv.empty
-                and plots_config.quantiles.surveillance.date_column
-                and plots_config.quantiles.surveillance.value_column
-            ):
-                location_surveillance_full[loc] = surv.rename(
-                    columns={
-                        plots_config.quantiles.surveillance.date_column: "date",
-                        plots_config.quantiles.surveillance.value_column: "value",
-                    }
-                )[["date", "value"]]
-
-            # Create filtered surveillance dataframe
-            surv_filtered = surv.copy()
-
-            # Filter surveillance data to start from timespan start (inferred from projection or calibration quantiles)
-            if not surv_filtered.empty:
-                # Use projection quantiles to get full timespan, fall back to calibration if not available
-                quantiles_for_timespan = proj_quant_raw if proj_quant_raw is not None else location_cal_quants.get(loc)
-
-                if quantiles_for_timespan is not None and "date" in quantiles_for_timespan.columns:
-                    # Infer timespan start from the earliest date in quantiles
-                    timespan_start = pd.to_datetime(quantiles_for_timespan["date"]).min().date()
-                    # Filter surveillance data to start from timespan start
-                    surv_filtered = surv_filtered[
-                        pd.to_datetime(surv_filtered[plots_config.quantiles.surveillance.date_column]).dt.date
-                        >= timespan_start
-                    ]
-
-            if (
-                not surv_filtered.empty
-                and plots_config.quantiles.surveillance.date_column
-                and plots_config.quantiles.surveillance.value_column
-            ):
-                location_surveillance_filtered[loc] = surv_filtered.rename(
-                    columns={
-                        plots_config.quantiles.surveillance.date_column: "date",
-                        plots_config.quantiles.surveillance.value_column: "value",
-                    }
-                )[["date", "value"]]
-
-                # Note: Per-output surveillance_points filtering will be applied later
-                # when generating each output, not here
-
-                # Get first surveillance date for projection filtering
-                if not location_surveillance_filtered[loc].empty:
-                    surveillance_start_date = pd.to_datetime(location_surveillance_filtered[loc]["date"]).min().date()
-
-        # Prepare projection quantiles - create both filtered and full versions
-        if proj_quant_raw is not None:
-            from datetime import timedelta
-
-            # Full version: apply horizon_max only (no surveillance_start_date filtering)
-            location_proj_quants_full[loc] = proj_quant_raw.copy()
-            if plots_config.quantiles.horizon_max is not None:
-                proj_dates_full = pd.to_datetime(location_proj_quants_full[loc]["date"]).dt.date
-                horizon_end_full = plots_config.reference_date + timedelta(weeks=plots_config.quantiles.horizon_max)
-                location_proj_quants_full[loc] = location_proj_quants_full[loc][
-                    proj_dates_full.values <= horizon_end_full
-                ]
-
-            # Filtered version: apply standard filtering
-            location_proj_quants_filtered[loc] = proj_quant_raw.copy()
-            proj_dates = pd.to_datetime(location_proj_quants_filtered[loc]["date"]).dt.date
-
-            # Start at first surveillance point if there's projection data before it
-            if surveillance_start_date is not None:
-                proj_start = proj_dates.min()
-                # Only filter if projection starts before first surveillance point
-                if proj_start < surveillance_start_date:
-                    location_proj_quants_filtered[loc] = location_proj_quants_filtered[loc][
-                        proj_dates.values >= surveillance_start_date
-                    ]
-
-            # End at horizon_max if specified
-            if plots_config.quantiles.horizon_max is not None:
-                horizon_end = plots_config.reference_date + timedelta(weeks=plots_config.quantiles.horizon_max)
-                proj_dates = pd.to_datetime(location_proj_quants_filtered[loc]["date"]).dt.date
-                location_proj_quants_filtered[loc] = location_proj_quants_filtered[loc][
-                    proj_dates.values <= horizon_end
-                ]
+        proj_quant_full, proj_quant_filtered = _prepare_projection_quantiles(
+            proj_quant_raw, surveillance_start_date, plots_config
+        )
+        if proj_quant_full is not None:
+            location_proj_quants_full[loc] = proj_quant_full
+        if proj_quant_filtered is not None:
+            location_proj_quants_filtered[loc] = proj_quant_filtered
 
     # Go over collected data, plot grid, and add to output dict
     if location_cal_quants or location_proj_quants_filtered or location_proj_quants_full:
         # Rename columns to have consistent naming for plotting
         # TODO: Calibration uses "data", projection uses "hospitalizations" - make this configurable
         for loc in location_cal_quants:
-            if "data" in location_cal_quants[loc].columns:
-                location_cal_quants[loc] = location_cal_quants[loc].rename(columns={"data": "value"})
+            location_cal_quants[loc] = _rename_value_column(location_cal_quants[loc], "data")
         for loc in location_proj_quants_filtered:
-            if "hospitalizations" in location_proj_quants_filtered[loc].columns:
-                location_proj_quants_filtered[loc] = location_proj_quants_filtered[loc].rename(
-                    columns={"hospitalizations": "value"}
-                )
+            location_proj_quants_filtered[loc] = _rename_value_column(
+                location_proj_quants_filtered[loc], "hospitalizations"
+            )
         for loc in location_proj_quants_full:
-            if "hospitalizations" in location_proj_quants_full[loc].columns:
-                location_proj_quants_full[loc] = location_proj_quants_full[loc].rename(
-                    columns={"hospitalizations": "value"}
-                )
+            location_proj_quants_full[loc] = _rename_value_column(location_proj_quants_full[loc], "hospitalizations")
 
         value_col = "value"
 
@@ -765,18 +772,27 @@ def generate_quantile_grid_plot(
                 logger.warning(f"Unknown output type: {output_type_name}")
                 continue
 
-            # Apply per-output surveillance_points filtering if needed
-            if surv_data_to_use and output_config.surveillance_points is not None:
-                surv_data_filtered_by_output = {}
-                for loc, surv_df in surv_data_to_use.items():
-                    surv_data_filtered_by_output[loc] = (
-                        surv_df.sort_values("date").tail(output_config.surveillance_points)
-                    )
-                surv_data_to_use = surv_data_filtered_by_output
+            # Apply per-output surveillance filtering if needed
+            if surv_data_to_use:
+                # Date-based filtering takes precedence over points-based filtering
+                if output_config.surveillance_start_date is not None:
+                    surv_data_filtered_by_output = {}
+                    start_date = pd.to_datetime(output_config.surveillance_start_date).date()
+                    for loc, surv_df in surv_data_to_use.items():
+                        surv_df_copy = surv_df.copy()
+                        surv_dates = pd.to_datetime(surv_df_copy["date"]).dt.date
+                        surv_data_filtered_by_output[loc] = surv_df_copy[surv_dates >= start_date]
+                    surv_data_to_use = surv_data_filtered_by_output
+                elif output_config.surveillance_points is not None:
+                    surv_data_filtered_by_output = {}
+                    for loc, surv_df in surv_data_to_use.items():
+                        surv_data_filtered_by_output[loc] = surv_df.sort_values("date").tail(
+                            output_config.surveillance_points
+                        )
+                    surv_data_to_use = surv_data_filtered_by_output
 
             # Apply per-output horizon_max if specified (overrides base config)
             if proj_quants_to_use and output_config.horizon_max is not None:
-                from datetime import timedelta
                 proj_quants_horizon_filtered = {}
                 for loc, proj_df in proj_quants_to_use.items():
                     proj_df_copy = proj_df.copy()
@@ -839,10 +855,13 @@ def generate_quantile_grid_plot(
 
                     if locations:
                         n_locations = len(locations)
-                        panels_per_row = output_config.columns if hasattr(output_config, 'columns') else plots_config.quantiles.grid.panels_per_row
-                        pairs_per_row = panels_per_row // 2  # Each location needs 2 panels
+                        configured_panels = plots_config.quantiles.grid.panels_per_row
+                        ncols = configured_panels + (configured_panels % 2)  # keep even count for pairs
+                        if ncols < 2:
+                            logger.warning("panels_per_row must be >= 2 for side_by_side; defaulting to 2 columns")
+                            ncols = 2
+                        pairs_per_row = ncols // 2  # Each location needs 2 panels
                         nrows = math.ceil(n_locations / pairs_per_row)
-                        ncols = panels_per_row
 
                         figsize = output_config.figsize if output_config.figsize else (4 * ncols, 3.6 * nrows)
                         fig, axes = plt.subplots(nrows, ncols, figsize=figsize, squeeze=False)
@@ -855,48 +874,95 @@ def generate_quantile_grid_plot(
                             ax_full = axes[row, col_start]  # Left panel of pair
                             ax_filtered = axes[row, col_start + 1]  # Right panel of pair
 
-                            cal_quant = location_cal_quants.get(location) if output_config.show_calibration and location_cal_quants else None
-                            proj_quant_full = location_proj_quants_full.get(location) if output_config.show_projection and location_proj_quants_full else None
+                            cal_quant = (
+                                location_cal_quants.get(location)
+                                if output_config.show_calibration and location_cal_quants
+                                else None
+                            )
+                            proj_quant_full = (
+                                location_proj_quants_full.get(location)
+                                if output_config.show_projection and location_proj_quants_full
+                                else None
+                            )
                             proj_quant_filtered = (
-                                location_proj_quants_filtered.get(location) if output_config.show_projection and location_proj_quants_filtered else None
+                                location_proj_quants_filtered.get(location)
+                                if output_config.show_projection and location_proj_quants_filtered
+                                else None
                             )
-                            surv_full = location_surveillance_full.get(location) if output_config.show_surveillance and location_surveillance_full else None
-                            surv_filtered = (
-                                location_surveillance_filtered.get(location) if output_config.show_surveillance and location_surveillance_filtered else None
-                            )
+
+                            # Apply per-output horizon override to both panels
+                            if output_config.horizon_max is not None:
+                                horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
+                                if proj_quant_full is not None:
+                                    proj_dates = pd.to_datetime(proj_quant_full["date"]).dt.date
+                                    proj_quant_full = proj_quant_full[proj_dates.values <= horizon_end]
+                                if proj_quant_filtered is not None:
+                                    proj_dates = pd.to_datetime(proj_quant_filtered["date"]).dt.date
+                                    proj_quant_filtered = proj_quant_filtered[proj_dates.values <= horizon_end]
+
+                            surv_full = None
+                            if (
+                                output_config.show_surveillance
+                                and location_surveillance_full
+                                and location in location_surveillance_full
+                            ):
+                                surv_full = location_surveillance_full[location].copy()
+                                if output_config.full_panel:
+                                    if output_config.full_panel.surveillance_start_date is not None:
+                                        start_date = pd.to_datetime(
+                                            output_config.full_panel.surveillance_start_date
+                                        ).date()
+                                        surv_dates = pd.to_datetime(surv_full["date"]).dt.date
+                                        surv_full = surv_full[surv_dates >= start_date]
+                                    elif output_config.full_panel.surveillance_points is not None:
+                                        surv_full = surv_full.sort_values("date").tail(
+                                            output_config.full_panel.surveillance_points
+                                        )
+
+                            surv_filtered = None
+                            if (
+                                output_config.show_surveillance
+                                and location_surveillance_filtered
+                                and location in location_surveillance_filtered
+                            ):
+                                surv_filtered = location_surveillance_filtered[location].copy()
+                                if output_config.filtered_panel:
+                                    if output_config.filtered_panel.surveillance_start_date is not None:
+                                        start_date = pd.to_datetime(
+                                            output_config.filtered_panel.surveillance_start_date
+                                        ).date()
+                                        surv_dates = pd.to_datetime(surv_filtered["date"]).dt.date
+                                        surv_filtered = surv_filtered[surv_dates >= start_date]
+                                    elif output_config.filtered_panel.surveillance_points is not None:
+                                        surv_filtered = surv_filtered.sort_values("date").tail(
+                                            output_config.filtered_panel.surveillance_points
+                                        )
                             fitting_window_start = (
-                                location_fitting_window_starts.get(location) if output_config.show_fitting_window_line and location_fitting_window_starts else None
+                                location_fitting_window_starts.get(location)
+                                if output_config.show_fitting_window_line and location_fitting_window_starts
+                                else None
                             )
                             fitting_window_end = (
-                                location_fitting_window_ends.get(location) if output_config.show_fitting_window_line and location_fitting_window_ends else None
+                                location_fitting_window_ends.get(location)
+                                if output_config.show_fitting_window_line and location_fitting_window_ends
+                                else None
                             )
 
-                            # Left panel: Full
-                            plot_calibration_projection(
+                            # Use core helper to draw both panels on provided axes
+                            plot_calibration_projection_sidebyside(
                                 calibration_quantiles=cal_quant,
-                                projection_quantiles=proj_quant_full,
+                                projection_quantiles_full=proj_quant_full,
+                                projection_quantiles_filtered=proj_quant_filtered,
+                                surveillance_full=surv_full,
+                                surveillance_filtered=surv_filtered,
                                 value_col=value_col,
                                 calibration_color=plots_config.quantiles.calibration.color,
                                 projection_color=plots_config.quantiles.projection.color,
-                                df_surveillance=surv_full,
                                 fitting_window_start=fitting_window_start,
                                 fitting_window_end=fitting_window_end,
                                 title=_format_location_name(location),
-                                ax=ax_full,
-                            )
-
-                            # Right panel: Filtered
-                            plot_calibration_projection(
-                                calibration_quantiles=cal_quant,
-                                projection_quantiles=proj_quant_filtered,
-                                value_col=value_col,
-                                calibration_color=plots_config.quantiles.calibration.color,
-                                projection_color=plots_config.quantiles.projection.color,
-                                df_surveillance=surv_filtered,
-                                fitting_window_start=fitting_window_start,
-                                fitting_window_end=fitting_window_end,
-                                title=_format_location_name(location),
-                                ax=ax_filtered,
+                                ax_full=ax_full,
+                                ax_filtered=ax_filtered,
                             )
 
                             # Hide legends except for leftmost column
@@ -922,7 +988,9 @@ def generate_quantile_grid_plot(
                         output_objs = []
                         for fig_output_type in plots_config.figure_output_types:
                             output_objs.append(
-                                figure_to_output_object(fig, "quantiles_grid_sidebyside", fig_output_type, plots_config.dpi)
+                                figure_to_output_object(
+                                    fig, "quantiles_grid_sidebyside", fig_output_type, plots_config.dpi
+                                )
                             )
                         out_dict["quantiles_grid_sidebyside"] = output_objs
                         plt.close(fig)

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -26,6 +26,106 @@ from .core import (
 logger = logging.getLogger(__name__)
 
 
+def _create_filtered_plot(
+    location: str,
+    cal_quant: pd.DataFrame | None,
+    proj_quant: pd.DataFrame | None,
+    df_surv: pd.DataFrame | None,
+    fitting_window_start: pd.Timestamp | None,
+    fitting_window_end: pd.Timestamp | None,
+    plots_config: PlotsConfig,
+    value_col: str,
+) -> tuple:
+    """
+    Create filtered quantile plot for a location.
+
+    Parameters
+    ----------
+    location : str
+        Location name
+    cal_quant : pd.DataFrame or None
+        Calibration quantiles
+    proj_quant : pd.DataFrame or None
+        Projection quantiles (filtered version)
+    df_surv : pd.DataFrame or None
+        Surveillance data (filtered version)
+    fitting_window_start : pd.Timestamp or None
+        Start of fitting window
+    fitting_window_end : pd.Timestamp or None
+        End of fitting window
+    plots_config : PlotsConfig
+        Plot configuration
+    value_col : str
+        Name of value column
+
+    Returns
+    -------
+    tuple
+        (fig, ax) matplotlib figure and axes
+    """
+    return plot_calibration_projection(
+        calibration_quantiles=cal_quant,
+        projection_quantiles=proj_quant,
+        value_col=value_col,
+        calibration_color=plots_config.quantiles.calibration.color,
+        projection_color=plots_config.quantiles.projection.color,
+        df_surveillance=df_surv,
+        fitting_window_start=fitting_window_start if plots_config.quantiles.fitting_window_line.show else None,
+        fitting_window_end=fitting_window_end if plots_config.quantiles.fitting_window_line.show else None,
+        title=_format_location_name(location),
+    )
+
+
+def _create_full_plot(
+    location: str,
+    cal_quant: pd.DataFrame | None,
+    proj_quant: pd.DataFrame | None,
+    df_surv: pd.DataFrame | None,
+    fitting_window_start: pd.Timestamp | None,
+    fitting_window_end: pd.Timestamp | None,
+    plots_config: PlotsConfig,
+    value_col: str,
+) -> tuple:
+    """
+    Create full quantile plot for a location.
+
+    Parameters
+    ----------
+    location : str
+        Location name
+    cal_quant : pd.DataFrame or None
+        Calibration quantiles
+    proj_quant : pd.DataFrame or None
+        Projection quantiles (full version)
+    df_surv : pd.DataFrame or None
+        Surveillance data (full version)
+    fitting_window_start : pd.Timestamp or None
+        Start of fitting window
+    fitting_window_end : pd.Timestamp or None
+        End of fitting window
+    plots_config : PlotsConfig
+        Plot configuration
+    value_col : str
+        Name of value column
+
+    Returns
+    -------
+    tuple
+        (fig, ax) matplotlib figure and axes
+    """
+    return plot_calibration_projection(
+        calibration_quantiles=cal_quant,
+        projection_quantiles=proj_quant,
+        value_col=value_col,
+        calibration_color=plots_config.quantiles.calibration.color,
+        projection_color=plots_config.quantiles.projection.color,
+        df_surveillance=df_surv,
+        fitting_window_start=fitting_window_start if plots_config.quantiles.fitting_window_line.show else None,
+        fitting_window_end=fitting_window_end if plots_config.quantiles.fitting_window_line.show else None,
+        title=_format_location_name(location),
+    )
+
+
 def get_locations_to_plot(calibrations: list[CalibrationOutput], single_config: bool | list[str]) -> set[str]:
     """
     Get set of locations to plot based on config.
@@ -262,18 +362,15 @@ def generate_single_quantile_plots(
 
         # Create filtered plot
         try:
-            fig, ax = plot_calibration_projection(
-                calibration_quantiles=cal_quant,
-                projection_quantiles=proj_quant_filtered,
-                value_col=value_col,
-                calibration_color=plots_config.quantiles.calibration.color,
-                projection_color=plots_config.quantiles.projection.color,
-                df_surveillance=df_surv_filtered,
-                fitting_window_start=(
-                    fitting_window_start if plots_config.quantiles.fitting_window_line.show else None
-                ),
-                fitting_window_end=(fitting_window_end if plots_config.quantiles.fitting_window_line.show else None),
-                title=_format_location_name(location),
+            fig, ax = _create_filtered_plot(
+                location,
+                cal_quant,
+                proj_quant_filtered,
+                df_surv_filtered,
+                fitting_window_start,
+                fitting_window_end,
+                plots_config,
+                value_col,
             )
 
             # Package output
@@ -289,18 +386,15 @@ def generate_single_quantile_plots(
 
         # Create full plot
         try:
-            fig, ax = plot_calibration_projection(
-                calibration_quantiles=cal_quant,
-                projection_quantiles=proj_quant_full,
-                value_col=value_col,
-                calibration_color=plots_config.quantiles.calibration.color,
-                projection_color=plots_config.quantiles.projection.color,
-                df_surveillance=df_surv_full,
-                fitting_window_start=(
-                    fitting_window_start if plots_config.quantiles.fitting_window_line.show else None
-                ),
-                fitting_window_end=(fitting_window_end if plots_config.quantiles.fitting_window_line.show else None),
-                title=_format_location_name(location),
+            fig, ax = _create_full_plot(
+                location,
+                cal_quant,
+                proj_quant_full,
+                df_surv_full,
+                fitting_window_start,
+                fitting_window_end,
+                plots_config,
+                value_col,
             )
 
             # Package output

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -881,7 +881,7 @@ def generate_quantile_grid_plot(
                                 df_surveillance=surv_full,
                                 fitting_window_start=fitting_window_start,
                                 fitting_window_end=fitting_window_end,
-                                title=f"{_format_location_name(location)} - Full",
+                                title=_format_location_name(location),
                                 ax=ax_full,
                             )
 
@@ -895,16 +895,20 @@ def generate_quantile_grid_plot(
                                 df_surveillance=surv_filtered,
                                 fitting_window_start=fitting_window_start,
                                 fitting_window_end=fitting_window_end,
-                                title=f"{_format_location_name(location)} - Filtered",
+                                title=_format_location_name(location),
                                 ax=ax_filtered,
                             )
 
-                            # Hide legends except for first pair
-                            if i != 0:
-                                for ax in [ax_full, ax_filtered]:
-                                    legend = ax.get_legend()
-                                    if legend is not None:
-                                        legend.remove()
+                            # Hide legends except for leftmost column
+                            # Only show legend on the left panel (col_start == 0)
+                            if col_start != 0:
+                                legend = ax_full.get_legend()
+                                if legend is not None:
+                                    legend.remove()
+                            # Always hide legend on right panel (filtered)
+                            legend = ax_filtered.get_legend()
+                            if legend is not None:
+                                legend.remove()
 
                         # Remove unused axes
                         for idx in range(n_locations * 2, nrows * ncols):

--- a/tests/test_general_validator.py
+++ b/tests/test_general_validator.py
@@ -19,9 +19,10 @@ from epymodelingsuite.schema.general import (
 )
 from epymodelingsuite.schema.output import (
     FlusightForecastOutput,
-    FlusightRateTrends,
+    ObservedValuesConfig,
     OutputConfig,
     OutputConfiguration,
+    OutputOptions,
     QuantilesOutput,
     TrajectoriesOutput,
 )
@@ -516,15 +517,20 @@ class TestWarnMismatchedObservedDataPaths:
     def test_no_warning_when_calibration_is_none(self, caplog):
         output_config = OutputConfig(
             output=OutputConfiguration(
+                options=OutputOptions(
+                    surveillance={
+                        "hosp": ObservedValuesConfig(
+                            data_path="data/output.csv",
+                            value_column="value",
+                            date_column="date",
+                            location_column="location",
+                        )
+                    }
+                ),
                 flusight_format=FlusightForecastOutput(
                     reference_date="2024-01-01",
-                    rate_trends=FlusightRateTrends(
-                        observed_data_path="data/output.csv",
-                        observed_value_column="value",
-                        observed_date_column="date",
-                        observed_location_column="location",
-                    ),
-                )
+                    rate_trends_source="hosp",
+                ),
             )
         )
         _warn_mismatched_observed_data_paths(None, output_config)
@@ -536,11 +542,11 @@ class TestWarnMismatchedObservedDataPaths:
         _warn_mismatched_observed_data_paths(calibration, output_config)
         assert "Observed data paths differ" not in caplog.text
 
-    def test_no_warning_when_rate_trends_is_none(self, caplog):
+    def test_no_warning_when_rate_trends_source_is_none(self, caplog):
         calibration = SimpleNamespace(observed_data_path="data/calibration.csv")
         output_config = OutputConfig(
             output=OutputConfiguration(
-                flusight_format=FlusightForecastOutput(reference_date="2024-01-01", rate_trends=None)
+                flusight_format=FlusightForecastOutput(reference_date="2024-01-01", rate_trends_source=None)
             )
         )
         _warn_mismatched_observed_data_paths(calibration, output_config)
@@ -550,15 +556,20 @@ class TestWarnMismatchedObservedDataPaths:
         calibration = SimpleNamespace(observed_data_path="data/same.csv")
         output_config = OutputConfig(
             output=OutputConfiguration(
+                options=OutputOptions(
+                    surveillance={
+                        "hosp": ObservedValuesConfig(
+                            data_path="data/same.csv",
+                            value_column="value",
+                            date_column="date",
+                            location_column="location",
+                        )
+                    }
+                ),
                 flusight_format=FlusightForecastOutput(
                     reference_date="2024-01-01",
-                    rate_trends=FlusightRateTrends(
-                        observed_data_path="data/same.csv",
-                        observed_value_column="value",
-                        observed_date_column="date",
-                        observed_location_column="location",
-                    ),
-                )
+                    rate_trends_source="hosp",
+                ),
             )
         )
         _warn_mismatched_observed_data_paths(calibration, output_config)
@@ -572,18 +583,23 @@ class TestWarnMismatchedObservedDataPaths:
         calibration = SimpleNamespace(observed_data_path="data/calibration.csv")
         output_config = OutputConfig(
             output=OutputConfiguration(
+                options=OutputOptions(
+                    surveillance={
+                        "hosp": ObservedValuesConfig(
+                            data_path="data/output.csv",
+                            value_column="value",
+                            date_column="date",
+                            location_column="location",
+                        )
+                    }
+                ),
                 flusight_format=FlusightForecastOutput(
                     reference_date="2024-01-01",
-                    rate_trends=FlusightRateTrends(
-                        observed_data_path="data/output.csv",
-                        observed_value_column="value",
-                        observed_date_column="date",
-                        observed_location_column="location",
-                    ),
-                )
+                    rate_trends_source="hosp",
+                ),
             )
         )
         _warn_mismatched_observed_data_paths(calibration, output_config)
         assert "Observed data paths differ between configs" in caplog.text
         assert "calibration='data/calibration.csv'" in caplog.text
-        assert "output.flusight_format.rate_trends='data/output.csv'" in caplog.text
+        assert "rate_trends_source ('hosp')='data/output.csv'" in caplog.text

--- a/tutorials/data/basic_output.yaml
+++ b/tutorials/data/basic_output.yaml
@@ -85,9 +85,12 @@ output:
           show_projection: true
           show_surveillance: true
           show_fitting_window_line: true
-          columns: 4                 # For grid: 2 location-pairs per row
+          full_panel:
+            surveillance_points: null  # Show all points (or use surveillance_start_date: "2024-09-14")
+          filtered_panel:
+            surveillance_points: 8     # Show last 8 points
           spacing: 0.3
-          figsize: null              # Auto-size
+          figsize: null                # Auto-size
 
       # Shared settings
       quantiles: [0.025, 0.25, 0.5, 0.75, 0.975]  # 95% CrI + IQR + median

--- a/tutorials/data/basic_output.yaml
+++ b/tutorials/data/basic_output.yaml
@@ -71,6 +71,7 @@ output:
           show_calibration: false
           show_projection: true
           show_surveillance: true
+          surveillance_source: hosp  # Reference surveillance source from options.surveillance
           show_fitting_window_line: true
           surveillance_points: 8    # Show most recent 8 points
           horizon_max: null         # Use base config value
@@ -80,6 +81,7 @@ output:
           show_calibration: false
           show_projection: true
           show_surveillance: true
+          surveillance_source: hosp  # Reference surveillance source from options.surveillance
           show_fitting_window_line: true
           surveillance_points: null  # Show all points
           horizon_max: null          # Use base config value
@@ -89,6 +91,7 @@ output:
           show_calibration: false
           show_projection: true
           show_surveillance: true
+          surveillance_source: hosp  # Reference surveillance source from options.surveillance
           show_fitting_window_line: true
           full_panel:
             surveillance_points: null  # Show all points (or use surveillance_start_date: "2024-09-14")

--- a/tutorials/data/basic_output.yaml
+++ b/tutorials/data/basic_output.yaml
@@ -24,7 +24,8 @@ output:
   # Set true for default behavior or use subfield 'generations'
   posteriors: true
 
-  # Shared options (defined before hub format so it can reference them)
+  # Shared options. Surveillance data defined here can be referenced in other sections.
+  # Use the key to reference the surveillance source elsewhere (e.g. rate_trends_source: hosp)
   options:
     surveillance:
       hosp:
@@ -46,20 +47,20 @@ output:
   # Visualization plots
   plots:
     figure_output_types:
-      - PNG
-    dpi: 150                # DPI for raster formats (png)
+      - PDF
+    dpi: 150                # DPI for raster formats (PNG)
 
     reference_date: "2025-04-05"  # Forecast reference date (horizon 0 for forecast horizon calculation)
 
     # Posterior distribution plots
     posterior:
-      single: false          # One plot per location (uses all locations from calibrations). Boolean or list of locations.
+      single: false         # One plot per location (uses all locations from calibrations). Boolean or list of locations.
       grid: true            # Grid plot with all locations
       bins: 30              # Number of histogram bins
 
     # Quantile ribbon plots
     quantiles:
-      single: false          # One plot per location
+      single: false         # One plot per location. Boolean or list of locations.
       grid:
         enabled: true       # Create multi-location grid
         panels_per_row: 4   # Number of panels per row in grid
@@ -71,38 +72,38 @@ output:
           show_calibration: false
           show_projection: true
           show_surveillance: true
-          surveillance_source: hosp  # Reference surveillance source from options.surveillance
+          surveillance_source: hosp       # Reference surveillance source from options.surveillance
           show_fitting_window_line: true
-          surveillance_points: 8    # Show most recent 8 points
-          horizon_max: null         # Use base config value
+          surveillance_points: 8          # Show most recent 8 points
+          horizon_max: null               # Use base config value
 
         # Full output: all surveillance points for full context
         - type: full
           show_calibration: false
           show_projection: true
           show_surveillance: true
-          surveillance_source: hosp  # Reference surveillance source from options.surveillance
+          surveillance_source: hosp        # Reference surveillance source from options.surveillance
           show_fitting_window_line: true
-          surveillance_points: null  # Show all points
-          horizon_max: null          # Use base config value
+          surveillance_points: null        # Show all points
+          horizon_max: null                # Use base config value
 
         # Side-by-side output: filtered and full combined
         - type: side_by_side
           show_calibration: false
           show_projection: true
           show_surveillance: true
-          surveillance_source: hosp  # Reference surveillance source from options.surveillance
+          surveillance_source: hosp        # Reference surveillance source from options.surveillance
           show_fitting_window_line: true
           full_panel:
-            surveillance_points: null  # Show all points (or use surveillance_start_date: "2024-09-14")
+            surveillance_points: null      # Show all points (or use surveillance_start_date: "2024-09-14")
           filtered_panel:
-            surveillance_points: 8     # Show last 8 points
+            surveillance_points: 8         # Show last 8 points
           spacing: 0.3
-          figsize: null                # Auto-size
+          figsize: null                    # Auto-size
 
       # Shared settings
       quantiles: [0.025, 0.25, 0.5, 0.75, 0.975]  # 95% CrI + IQR + median
-      horizon_max: 3        # Base maximum forecast horizon (weeks ahead). Can be overridden per output.
+      horizon_max: 3                              # Base maximum forecast horizon (weeks ahead). Can be overridden per output.
 
       # Shared styling (colors only, show flags moved to outputs)
       calibration:

--- a/tutorials/data/basic_output.yaml
+++ b/tutorials/data/basic_output.yaml
@@ -59,29 +59,51 @@ output:
         enabled: true       # Create multi-location grid
         panels_per_row: 4   # Number of panels per row in grid
 
-      quantiles: [0.025, 0.25, 0.5, 0.75, 0.975]  # 95% CrI + IQR + median
-      horizon_max: 3        # Maximum forecast horizon (weeks ahead) to display. Set to null to show all horizons.
+      # Output configurations - specify which plot types to generate
+      outputs:
+        # Filtered output: limited surveillance points for forecast focus
+        - type: filtered
+          show_calibration: false
+          show_projection: true
+          show_surveillance: true
+          show_fitting_window_line: true
+          surveillance_points: 8    # Show most recent 8 points
+          horizon_max: null         # Use base config value
 
-      # Calibration period settings
+        # Full output: all surveillance points for full context
+        - type: full
+          show_calibration: false
+          show_projection: true
+          show_surveillance: true
+          show_fitting_window_line: true
+          surveillance_points: null  # Show all points
+          horizon_max: null          # Use base config value
+
+        # Side-by-side output: filtered and full combined
+        - type: side_by_side
+          show_calibration: false
+          show_projection: true
+          show_surveillance: true
+          show_fitting_window_line: true
+          columns: 4                 # For grid: 2 location-pairs per row
+          spacing: 0.3
+          figsize: null              # Auto-size
+
+      # Shared settings
+      quantiles: [0.025, 0.25, 0.5, 0.75, 0.975]  # 95% CrI + IQR + median
+      horizon_max: 3        # Base maximum forecast horizon (weeks ahead). Can be overridden per output.
+
+      # Shared styling (colors only, show flags moved to outputs)
       calibration:
-        show: true
         color: "C0"
 
-      # Projection period settings
       projection:
-        show: true
         color: "C1"
 
-      # Surveillance data overlay settings
+      # Surveillance data source (show flag moved to outputs)
       surveillance:
-        show: true
         data_path: data/flu_hosp_24.csv
         value_column: hospitalizations
         date_column: target_end_date
         location_column: geo_value
-        surveillance_points: 8  # Number of most recent surveillance points to display. Set to null to show all points.
-
-      # Fitting window end line settings
-      fitting_window_line:
-        show: true          # Show vertical line at end of calibration/fitting window
 

--- a/tutorials/data/basic_output.yaml
+++ b/tutorials/data/basic_output.yaml
@@ -46,6 +46,9 @@ output:
 
   # Visualization plots
   plots:
+
+    # Output formats for plots. You can specify multiple formats.
+    # Supported formats: PDF, PNG, SVG
     figure_output_types:
       - PDF
     dpi: 150                # DPI for raster formats (PNG)

--- a/tutorials/data/basic_output.yaml
+++ b/tutorials/data/basic_output.yaml
@@ -5,6 +5,16 @@ output:
     version: "0.0.1"
     date: "2038-01-19"
 
+  # Shared options. Surveillance data defined here can be referenced in other sections.
+  # Use the key to reference the surveillance source elsewhere (e.g. rate_trends_source: hosp)
+  options:
+    surveillance:
+      hosp:
+        data_path: data/flu_hosp_24.csv
+        value_column: hospitalizations
+        date_column: target_end_date
+        location_column: geo_value
+
   # Output formats for tabular data (CSVBytes saves as .csv.gz files)
   tabular_output_types:
     - CSVBytes
@@ -23,16 +33,6 @@ output:
 
   # Set true for default behavior or use subfield 'generations'
   posteriors: true
-
-  # Shared options. Surveillance data defined here can be referenced in other sections.
-  # Use the key to reference the surveillance source elsewhere (e.g. rate_trends_source: hosp)
-  options:
-    surveillance:
-      hosp:
-        data_path: data/flu_hosp_24.csv
-        value_column: hospitalizations
-        date_column: target_end_date
-        location_column: geo_value
 
   # Hub format
   flusight_format:
@@ -60,6 +60,12 @@ output:
 
     # Quantile ribbon plots
     quantiles:
+
+      # Shared settings
+      quantiles: [0.025, 0.25, 0.5, 0.75, 0.975]  # 95% CrI + IQR + median
+      horizon_max: 3                              # Base maximum forecast horizon (weeks ahead). Can be overridden per output.
+
+      # Plot layout settings
       single: false         # One plot per location. Boolean or list of locations.
       grid:
         enabled: true       # Create multi-location grid
@@ -100,10 +106,6 @@ output:
             surveillance_points: 8         # Show last 8 points
           spacing: 0.3
           figsize: null                    # Auto-size
-
-      # Shared settings
-      quantiles: [0.025, 0.25, 0.5, 0.75, 0.975]  # 95% CrI + IQR + median
-      horizon_max: 3                              # Base maximum forecast horizon (weeks ahead). Can be overridden per output.
 
       # Shared styling (colors only, show flags moved to outputs)
       calibration:

--- a/tutorials/data/basic_output.yaml
+++ b/tutorials/data/basic_output.yaml
@@ -24,21 +24,7 @@ output:
   # Set true for default behavior or use subfield 'generations'
   posteriors: true
 
-  # Hub format
-  flusight_format:
-    reference_date: "2025-04-05"
-    rate_trends:
-        observed_data_path: data/flu_hosp_24.csv
-        observed_value_column: hospitalizations
-        observed_date_column: target_end_date
-        observed_location_column: geo_value
-
-  # Model metadata is always generated, even if the model_meta field is not present.
-  # Use the model_meta field to record projection parameters.
-  model_meta:
-    projection_parameters: true
-
-  # Shared options
+  # Shared options (defined before hub format so it can reference them)
   options:
     surveillance:
       hosp:
@@ -46,6 +32,16 @@ output:
         value_column: hospitalizations
         date_column: target_end_date
         location_column: geo_value
+
+  # Hub format
+  flusight_format:
+    reference_date: "2025-04-05"
+    rate_trends_source: hosp  # References surveillance source from options.surveillance
+
+  # Model metadata is always generated, even if the model_meta field is not present.
+  # Use the model_meta field to record projection parameters.
+  model_meta:
+    projection_parameters: true
 
   # Visualization plots
   plots:


### PR DESCRIPTION
## Summary
Reorganized output config file with centralized surveillance data definition and additional plot options

## Changes made
- Added side-by-side plot
- Added per-output plot configuration
  - Toggle calibration/projection/surveillance visibility
  - Set surveillance data filtering (by points or date)
  - Set forecast horizon limits
  - Panel-specific settings for side-by-side plots
```yaml
plots:
  quantiles:
    outputs:
      - type: filtered          # Show recent surveillance points
        surveillance_points: 8
      - type: full              # Show all surveillance data
      - type: side_by_side      # Compare filtered and full views
```
- Centralized surveillance data configuration at `output.options.surveillance`
  - The named source can be referenced in other sections (e.g. `rate_trends_source: hosp`)
  - Updated rate trends and ED visits schema to use `*_source` instead of directly defining surveillance details.

```yaml
output:
  options:
    surveillance:
      hosp:                    # Named source
        data_path: data/flu_hosp_24.csv
        value_column: hospitalizations
        date_column: target_end_date
        location_column: geo_value

  flusight_format:
    rate_trends_source: hosp   # Reference by name

  plots:
    quantiles:
      outputs:
        - surveillance_source: hosp  # Reference by name
```

See [basic_output.yaml](https://github.com/mobs-lab/epymodelingsuite/blob/13166ea50ac967ba4fb24a1ab1f2c5622592933d/tutorials/data/basic_output.yaml) for full examples.
