### PR TITLE
Fix get_flusight_quantiles to return correct quantiles

### DIFF
--- a/epymodelingsuite/schema/output.py
+++ b/epymodelingsuite/schema/output.py
@@ -69,14 +69,34 @@ class Covid19ForecastOutput(BaseModel):
 def get_flusight_quantiles() -> list[float]:
     """
     Return a list containing the quantiles needed for FluSight submissions.
+
     The set of quantiles is defined at https://github.com/cdcepi/FluSight-forecast-hub/tree/main/model-output#quantile-output
     """
-    import numpy as np
-
-    # This has floating point errors
-    quantiles = np.append(np.append([0.01, 0.025], np.arange(0.05, 0.95 + 0.05, 0.05)), [0.975, 0.99])
-    return [round(_, 2) for _ in quantiles]
-    # 0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.975, and 0.99
+    return [
+        0.01,
+        0.025,
+        0.05,
+        0.1,
+        0.15,
+        0.2,
+        0.25,
+        0.3,
+        0.35,
+        0.4,
+        0.45,
+        0.5,
+        0.55,
+        0.6,
+        0.65,
+        0.7,
+        0.75,
+        0.8,
+        0.85,
+        0.9,
+        0.95,
+        0.975,
+        0.99,
+    ]
 
 
 def get_quantile_ribbon_default() -> list[float]:


### PR DESCRIPTION
`get_flusight_quantiles()` was not exporting the FluSight quantiles, which came from rounding at 2nd decimal point.
- Exported: 0.01, **0.02**, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, **0.98**, 0.99
- Should be: 0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95, 0.975, 0.99 
