### PR TITLE
Add 'id' field to Meta class in common.py

### DIFF
--- a/epymodelingsuite/schema/common.py
+++ b/epymodelingsuite/schema/common.py
@@ -42,6 +42,7 @@ class DateParameter(BaseModel):
 class Meta(BaseModel):
     """General metadata section."""
 
+    id: str | None = Field(None, description="ID of the configuration.")
     description: str | None = Field(None, description="Description of the experiment / configurations.")
     author: str | None = Field(None, description="Author of the experiment / configurations.")
     version: str | float | None = Field(None, description="Version of the experiment / configurations.")


### PR DESCRIPTION
Add 'id' field to meta class, so that it can be used in output file paths.