### PR TITLE
Add context support to `post_hoc_transformation`

### DIFF
--- a/epymodelingsuite/builders/orchestrators.py
+++ b/epymodelingsuite/builders/orchestrators.py
@@ -728,6 +728,20 @@ def make_simulate_wrapper(
     post_hoc_transformation: Callable | None, optional
             Transform simulation results with a post-hoc transformation function
             before returning in simulate wrapper.
+
+            The function can optionally accept a 'context' keyword argument containing:
+            - params: dict of all simulation parameters (including calibrated values)
+            - basemodel: BaseEpiModel configuration object
+            - timespan: Timespan object with actual simulation dates
+            - observed_data: DataFrame of observed data for this location
+            - intervention_types: list of intervention type strings
+            - projection: bool indicating calibration vs projection mode
+            - location: str location/population name
+
+            Example signatures:
+                def transform(trajectory): ...  # Basic signature (still supported)
+                def transform(trajectory, context=None): ...  # With optional context
+                def transform(trajectory, **kwargs): ...  # Flexible signature
     rng : np.random.Generator | None, optional
             Random number generator for reproducible simulations.
             If None, a default generator will be created.
@@ -872,9 +886,29 @@ def make_simulate_wrapper(
 
         # 12. Apply post-hoc transformation
         if post_hoc_transformation:
+            # Build context dict
+            context = {
+                "params": params,
+                "basemodel": basemodel,
+                "timespan": timespan,
+                "observed_data": observed_data,
+                "intervention_types": intervention_types,
+                "projection": params["projection"],
+                "location": model.population.name,
+            }
+
             try:
-                results = post_hoc_transformation(results)
+                # Try calling with context first
+                results = post_hoc_transformation(results, context=context)
+            except TypeError:
+                # Function doesn't accept context, retry without it
+                try:
+                    results = post_hoc_transformation(results)
+                except Exception as e:
+                    msg = f"Post-hoc transformation failed with transformation function {post_hoc_transformation}, returning non-transformed results. Error: {e}"
+                    logger.warning(msg)
             except Exception as e:
+                # Other errors (not TypeError)
                 msg = f"Post-hoc transformation failed with transformation function {post_hoc_transformation}, returning non-transformed results. Error: {e}"
                 logger.warning(msg)
 

--- a/epymodelingsuite/builders/orchestrators.py
+++ b/epymodelingsuite/builders/orchestrators.py
@@ -885,7 +885,10 @@ def make_simulate_wrapper(
             return {"data": np.full(len(data_dates), 0)}
 
         # 12. Apply post-hoc transformation
+        logger.debug(f"[DEBUG] post_hoc_transformation = {post_hoc_transformation}")
+        logger.debug(f"[DEBUG] post_hoc_transformation type = {type(post_hoc_transformation)}")
         if post_hoc_transformation:
+            logger.info(f"[DEBUG] Applying post-hoc transformation")
             # Build context dict
             context = {
                 "params": params,
@@ -899,11 +902,15 @@ def make_simulate_wrapper(
 
             try:
                 # Try calling with context first
+                logger.debug(f"[DEBUG] Calling post_hoc_transformation with context")
                 results = post_hoc_transformation(results, context=context)
+                logger.info(f"[DEBUG] Post-hoc transformation succeeded with context")
             except TypeError:
                 # Function doesn't accept context, retry without it
                 try:
+                    logger.debug(f"[DEBUG] Calling post_hoc_transformation without context")
                     results = post_hoc_transformation(results)
+                    logger.info(f"[DEBUG] Post-hoc transformation succeeded without context")
                 except Exception as e:
                     msg = f"Post-hoc transformation failed with transformation function {post_hoc_transformation}, returning non-transformed results. Error: {e}"
                     logger.warning(msg)
@@ -911,6 +918,8 @@ def make_simulate_wrapper(
                 # Other errors (not TypeError)
                 msg = f"Post-hoc transformation failed with transformation function {post_hoc_transformation}, returning non-transformed results. Error: {e}"
                 logger.warning(msg)
+        else:
+            logger.warning(f"[DEBUG] No post-hoc transformation to apply (is None)")
 
         # 13. Format output based on mode
         # Projection: return full trajectories (flattened + padded)

--- a/epymodelingsuite/builders/utils.py
+++ b/epymodelingsuite/builders/utils.py
@@ -32,7 +32,9 @@ def get_data_in_window(data: pd.DataFrame, calibration: CalibrationConfig) -> pd
     return data.loc[mask]
 
 
-def get_data_in_location(data: pd.DataFrame, population_name: str, location_key: str) -> pd.DataFrame:
+def get_data_in_location(
+    data: pd.DataFrame, population_name: str, location_key: str, location_format: str = "ISO"
+) -> pd.DataFrame:
     """
     Get data for a specific location.
 
@@ -44,6 +46,9 @@ def get_data_in_location(data: pd.DataFrame, population_name: str, location_key:
         Name of the population/location.
     location_key : str
         The column name containing location identifiers.
+    location_format : str
+        Format of location identifiers in the data. Options: ISO, FIPS, abbreviation, name, epydemix_population.
+        Default is "ISO".
 
     Returns
     -------
@@ -51,4 +56,13 @@ def get_data_in_location(data: pd.DataFrame, population_name: str, location_key:
         Filtered data for the location.
     """
     location_iso = convert_location_name_format(population_name, "ISO")
-    return data[data[location_key] == location_iso]
+
+    if location_format == "ISO":
+        # Direct match (current behavior)
+        return data[data[location_key] == location_iso]
+    else:
+        # Convert observed data values to ISO using known input format
+        data_iso = data[location_key].apply(
+            lambda x: convert_location_name_format(str(x), "ISO", input_format=location_format)
+        )
+        return data[data_iso == location_iso]

--- a/epymodelingsuite/dispatcher/builder.py
+++ b/epymodelingsuite/dispatcher/builder.py
@@ -429,10 +429,8 @@ def build_calibration(
     # using the earliest start_date before creating ABCSamplers.
     models = setup_interventions(models, basemodel, intervention_types, sampled_start_timespan)
 
-    # Collect user-defined post-hoc transformation function
+    # Extract UDF functions (now wrapped in PicklableFunction for correct serialization)
     post_hoc_func = calibration.post_hoc_transformation.user_function if calibration.post_hoc_transformation else None
-
-    # Collect user-defined distance function
     dist_func = (
         dist_func_dict[calibration.distance_function]
         if isinstance(calibration.distance_function, str)

--- a/epymodelingsuite/dispatcher/builder.py
+++ b/epymodelingsuite/dispatcher/builder.py
@@ -70,19 +70,24 @@ def count_nans_at_start(arr: np.ndarray) -> int:
     int
         The number of NaNs found prepended to the array.
     """
+    # Handle empty array case
+    if arr.size == 0:
+        return 0
+
     # Create a boolean mask for NaN values
     mask = np.isnan(arr)
 
-    # Find the index of the first non-NaN value
-    first_non_nan_index = np.argmax(~mask)
-
-    # If no values are NaN, return 0
-    # If all, return len(arr)
+    # If all values are NaN, return len(arr)
     if mask.all():
         return len(arr)
-    if mask.any():
-        return first_non_nan_index
-    return 0
+
+    # If no values are NaN, return 0
+    if not mask.any():
+        return 0
+
+    # Find the index of the first non-NaN value
+    first_non_nan_index = np.argmax(~mask)
+    return first_non_nan_index
 
 
 def dist_func_date_alignment_wrapper(dist_func: Callable) -> Callable:

--- a/epymodelingsuite/dispatcher/builder.py
+++ b/epymodelingsuite/dispatcher/builder.py
@@ -448,9 +448,10 @@ def build_calibration(
     observed_in_window = get_data_in_window(observed_raw, calibration)
     calibrators = []
     location_column = calibration.comparison[0].observed_location_column
+    location_format = calibration.comparison[0].observed_location_format
 
     for model in models:
-        observed_data = get_data_in_location(observed_in_window, model.population.name, location_column)
+        observed_data = get_data_in_location(observed_in_window, model.population.name, location_column, location_format)
         vax_state = (
             get_data_in_location(earliest_vax, model.population.name, "location") if earliest_vax is not None else None
         )

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -1322,7 +1322,11 @@ def generate_calibration_outputs(
 
     # Covid19 Forecast Hub
     elif output.covid19_format:
-        pass
+        hub_format_output = pd.DataFrame()  # TODO: implement covid19 format
+
+    else:
+        # No hub format specified
+        hub_format_output = pd.DataFrame()
 
     ### Model Metadata
     if output.model_meta:

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -1321,7 +1321,7 @@ def generate_calibration_outputs(
         )
 
     # Covid19 Forecast Hub
-    elif output.quantiles.covid19_format:
+    elif output.covid19_format:
         pass
 
     ### Model Metadata

--- a/epymodelingsuite/dispatcher/runner.py
+++ b/epymodelingsuite/dispatcher/runner.py
@@ -191,7 +191,7 @@ def run_calibration_with_projection(
         if telemetry:
             calibration_duration = time.time() - calibration_start
             telemetry.capture_calibration(
-                output, calibration_duration, error=f"Calibration error: {e}", calibration_strategy=configs.calibration
+                output, calibration_duration, error=f"Calibration error: {e}", builder_output=configs
             )
         raise RuntimeError(f"Error during calibration: {e}")
 

--- a/epymodelingsuite/schema/calibration.py
+++ b/epymodelingsuite/schema/calibration.py
@@ -95,6 +95,10 @@ class ComparisonSpec(BaseModel):
     observed_location_column: str = Field(
         default="geo_value", description="Name of column containing location identifiers in observed data CSV"
     )
+    observed_location_format: str = Field(
+        default="ISO",
+        description="Format of location identifiers in observed data. Options: ISO, FIPS, abbreviation, name, epydemix_population",
+    )
     simulation: list[str] = Field(description="List of transition names to sum for comparison (e.g. I_to_R)")
 
 

--- a/epymodelingsuite/schema/calibration.py
+++ b/epymodelingsuite/schema/calibration.py
@@ -124,6 +124,23 @@ class UserDefinedFunction(BaseModel):
     """
     Specifications for user-defined functions (i.e. custom distance function, or post-hoc transformation function).
     Functions will be imported from the specified script and applied within the simulate wrapper.
+
+    For post-hoc transformation functions, the function can optionally accept a 'context' keyword argument
+    containing simulation metadata and calibrated parameters:
+
+    Expected signatures:
+        - def transform(trajectory): ...  # Basic signature (still supported)
+        - def transform(trajectory, context=None): ...  # With optional context parameter
+        - def transform(trajectory, **kwargs): ...  # Flexible signature accepting kwargs
+
+    Context dictionary structure (when provided):
+        - params: dict of all simulation parameters (including calibrated values like beta, gamma)
+        - basemodel: BaseEpiModel configuration object
+        - timespan: Timespan object with actual simulation dates
+        - observed_data: DataFrame of observed data for this location
+        - intervention_types: list of intervention type strings
+        - projection: bool indicating calibration vs projection mode
+        - location: str location/population name
     """
 
     user_script_path: str = Field(description="Path to script containing user-defined functions.")
@@ -157,7 +174,11 @@ class CalibrationConfiguration(BaseModel):
 
     strategy: CalibrationStrategy = Field(description="Calibration strategy configuration")
     post_hoc_transformation: UserDefinedFunction | None = Field(
-        None, description="Transformation function to apply to simulation results."
+        None,
+        description="Transformation function to apply to simulation results. "
+        "The function can optionally accept a 'context' keyword argument with simulation metadata "
+        "(params, basemodel, timespan, observed_data, projection, location). See UserDefinedFunction "
+        "docstring for details.",
     )
 
     # Sampler options, passed directly when initializing ABCSampler

--- a/epymodelingsuite/schema/calibration.py
+++ b/epymodelingsuite/schema/calibration.py
@@ -149,7 +149,11 @@ class UserDefinedFunction(BaseModel):
     @computed_field
     @property
     def user_function(self) -> Callable:
-        """Import the user defined function and populate a computed field in the schema model."""
+        """
+        Import the user defined function and populate a computed field in the schema model.
+
+        Returns a PicklableFunction wrapper that can be serialized and deserialized correctly.
+        """
         import sys
         import types
         from importlib import import_module
@@ -164,9 +168,56 @@ class UserDefinedFunction(BaseModel):
             sys.modules[module_name] = new_module
             module = import_module(module_name)
             user_func = getattr(module, self.user_function_name)
+
+            # Wrap in a picklable function class
+            return PicklableFunction(self.user_script_path, self.user_function_name, user_func)
         except Exception as e:
             raise RuntimeError(f"Error loading user-defined function {self.user_function_name}: {e}")
-        return user_func
+
+
+class PicklableFunction:
+    """
+    Wrapper for user-defined functions that handles pickling/unpickling correctly.
+
+    When pickled, stores the script path and function name instead of the function object.
+    When unpickled, reloads the function from the script file.
+    """
+
+    def __init__(self, script_path: str, function_name: str, func: Callable):
+        self.script_path = script_path
+        self.function_name = function_name
+        self._func = func
+
+    def __call__(self, *args, **kwargs):
+        """Call the wrapped function."""
+        return self._func(*args, **kwargs)
+
+    def __reduce__(self):
+        """Custom pickle protocol: store path and name, reload on unpickle."""
+        return (_reload_picklable_function, (self.script_path, self.function_name))
+
+
+def _reload_picklable_function(script_path: str, function_name: str) -> PicklableFunction:
+    """
+    Reload a PicklableFunction from script path and function name.
+
+    This function is called during unpickling to reconstruct the function.
+    """
+    import sys
+    import types
+    from importlib import import_module
+    from importlib.machinery import SourceFileLoader
+
+    module_name = "user_defined_module"
+    loader = SourceFileLoader(module_name, script_path)
+    code = loader.get_code(module_name)
+    new_module = types.ModuleType(loader.name)
+    exec(code, new_module.__dict__)
+    sys.modules[module_name] = new_module
+    module = import_module(module_name)
+    user_func = getattr(module, function_name)
+
+    return PicklableFunction(script_path, function_name, user_func)
 
 
 class CalibrationConfiguration(BaseModel):

--- a/epymodelingsuite/utils/location.py
+++ b/epymodelingsuite/utils/location.py
@@ -34,7 +34,7 @@ def get_flusight_population(location: str) -> int:
     ].iloc[0]
 
 
-def convert_location_name_format(value: str, output_format: str) -> str:
+def convert_location_name_format(value: str, output_format: str, input_format: str | None = None) -> str:
     """
     Convert location name from any valid format to the specified format.
 
@@ -49,6 +49,8 @@ def convert_location_name_format(value: str, output_format: str) -> str:
     ----------
             value (str): The location name to convert, in any valid format.
             output_format (str): The location name format to convert to, either "ISO", "epydemix_population", "name", "abbreviation", or "FIPS".
+            input_format (str | None): Optional. The format of the input value. If provided, enables direct lookup
+                    instead of auto-detection, which is more efficient for batch conversions.
 
     Returns
     -------
@@ -56,12 +58,6 @@ def convert_location_name_format(value: str, output_format: str) -> str:
     """
     # Retrieve codebook
     codebook = get_location_codebook()
-
-    # Find row with input value
-    location = codebook[codebook.isin([value]).any(axis=1)]
-
-    # Ensure value exists
-    assert not location.empty, f"Supplied location value {value} does not match any valid format"
 
     # Match format strings to codebook columns
     format_dict = {
@@ -71,6 +67,18 @@ def convert_location_name_format(value: str, output_format: str) -> str:
         "abbreviation": "location_abbreviation",
         "FIPS": "location_code",
     }
+
+    # Find row with input value
+    if input_format is not None:
+        # Direct lookup using known input format (more efficient)
+        input_col = format_dict[input_format]
+        location = codebook[codebook[input_col] == value]
+    else:
+        # Auto-detect by searching all columns (current behavior)
+        location = codebook[codebook.isin([value]).any(axis=1)]
+
+    # Ensure value exists
+    assert not location.empty, f"Supplied location value {value} does not match any valid format"
 
     # Location name in requested format
     result = location[format_dict[output_format]].values[0]

--- a/tests/builders/test_make_simulate_wrapper.py
+++ b/tests/builders/test_make_simulate_wrapper.py
@@ -674,3 +674,140 @@ class TestMakeSimulateWrapper:
             assert "date" in result
             # Should NOT have any custom transformed compartments
             assert "I_plus_R_total" not in result
+
+    def test_wrapper_with_post_hoc_transformation_receives_context(
+        self, base_model_config, mock_calibration, data_state
+    ):
+        """
+        Test that post-hoc transformation function receives context dict.
+
+        Tests:
+        - Transformation function is called with context keyword argument
+        - context contains expected keys (params, basemodel, timespan, observed_data, etc.)
+        - Function can access calibrated parameter values via context['params']
+        - Function can access model config via context['basemodel']
+        - Function can access actual dates via context['timespan']
+        - Works with optional context argument (backward compatible)
+        """
+        models, _ = create_model_collection(base_model_config, None)
+        model = models[0]
+
+        # Track what context was passed to the transformation
+        captured_context = {}
+
+        def context_aware_transformation(trajectory, context=None):
+            """Transformation that captures context for inspection."""
+            import copy
+
+            # Capture context for testing
+            if context is not None:
+                captured_context.update(context)
+
+            traj = copy.deepcopy(trajectory)
+            # Use context if available
+            if context:
+                beta = context["params"].get("beta", 0)
+                location = context["location"]
+                # Add compartment with info from context
+                traj.compartments["test_compartment"] = traj.compartments["S_total"] * beta
+
+            return traj
+
+        wrapper = make_simulate_wrapper(
+            basemodel=base_model_config,
+            calibration=mock_calibration,
+            observed_data=data_state,
+            intervention_types=[],
+            post_hoc_transformation=context_aware_transformation,
+        )
+
+        # Run in projection mode
+        params = {
+            "epimodel": model,
+            "end_date": date(2024, 3, 31),
+            "projection": True,
+            "beta": 0.6,
+            "gamma": 0.1,
+        }
+        result = wrapper(params)
+
+        # Verify context was passed
+        assert captured_context, "Context should have been passed to transformation function"
+
+        # Verify context has expected keys
+        assert "params" in captured_context
+        assert "basemodel" in captured_context
+        assert "timespan" in captured_context
+        assert "observed_data" in captured_context
+        assert "intervention_types" in captured_context
+        assert "projection" in captured_context
+        assert "location" in captured_context
+
+        # Verify context content
+        assert captured_context["params"]["beta"] == 0.6
+        assert captured_context["params"]["gamma"] == 0.1
+        assert captured_context["params"]["projection"] is True
+        assert captured_context["projection"] is True
+        # Location name is transformed from "US-CA" to "United_States_California"
+        assert captured_context["location"] == "United_States_California"
+        assert isinstance(captured_context["basemodel"], BaseEpiModel)
+        assert isinstance(captured_context["timespan"], Timespan)
+        assert isinstance(captured_context["observed_data"], pd.DataFrame)
+        assert isinstance(captured_context["intervention_types"], list)
+
+        # Verify transformation still worked
+        if result:
+            assert "test_compartment" in result
+
+    def test_wrapper_with_post_hoc_transformation_without_context_arg(
+        self, base_model_config, mock_calibration, data_state
+    ):
+        """
+        Test that transformation functions without context argument still work.
+
+        Tests:
+        - Functions with basic signature (only accepting trajectory) continue to work
+        - No error when function doesn't accept context keyword
+        - TypeError is caught and function is retried without context
+        - Backward compatibility is maintained
+        """
+        models, _ = create_model_collection(base_model_config, None)
+        model = models[0]
+
+        # Track that the function was called
+        call_count = {"count": 0}
+
+        def basic_transformation(trajectory):
+            """Transformation with basic signature that doesn't accept context."""
+            import copy
+
+            call_count["count"] += 1
+            traj = copy.deepcopy(trajectory)
+            traj.compartments["basic_compartment"] = traj.compartments["S_total"] * 2
+            return traj
+
+        wrapper = make_simulate_wrapper(
+            basemodel=base_model_config,
+            calibration=mock_calibration,
+            observed_data=data_state,
+            intervention_types=[],
+            post_hoc_transformation=basic_transformation,
+        )
+
+        # Run in projection mode
+        params = {
+            "epimodel": model,
+            "end_date": date(2024, 3, 31),
+            "projection": True,
+            "beta": 0.5,
+            "gamma": 0.1,
+        }
+        result = wrapper(params)
+
+        # Verify function was called
+        assert call_count["count"] > 0, "Transformation function should have been called"
+
+        # Verify transformation still worked despite not accepting context
+        if result:
+            assert "basic_compartment" in result
+            assert isinstance(result["basic_compartment"], np.ndarray)

--- a/tests/builders/test_make_simulate_wrapper.py
+++ b/tests/builders/test_make_simulate_wrapper.py
@@ -554,3 +554,123 @@ class TestMakeSimulateWrapper:
                 observed_data=observed_data_with_duplicates,
                 intervention_types=[],
             )
+
+    def test_wrapper_with_post_hoc_transformation(self, base_model_config, mock_calibration, data_state):
+        """
+        Test that wrapper correctly applies post-hoc transformation function.
+
+        Tests:
+        - Post-hoc transformation is applied to simulation results
+        - Transformation function receives Trajectory object
+        - Transformation output is used in final results
+        - Works in both calibration and projection modes
+        """
+        models, _ = create_model_collection(base_model_config, None)
+        model = models[0]
+
+        # Create a simple transformation function that adds a new compartment
+        def test_transformation(trajectory):
+            """Add a new compartment 'I_plus_R' that sums I and R compartments."""
+            import copy
+
+            traj = copy.deepcopy(trajectory)
+            # Sum all I compartments with all R compartments (across age groups)
+            i_keys = [k for k in traj.compartments.keys() if k.startswith("I_")]
+            r_keys = [k for k in traj.compartments.keys() if k.startswith("R_")]
+
+            if i_keys and r_keys:
+                i_total = sum(traj.compartments[k] for k in i_keys)
+                r_total = sum(traj.compartments[k] for k in r_keys)
+                traj.compartments["I_plus_R_total"] = i_total + r_total
+
+            return traj
+
+        wrapper = make_simulate_wrapper(
+            basemodel=base_model_config,
+            calibration=mock_calibration,
+            observed_data=data_state,
+            intervention_types=[],
+            post_hoc_transformation=test_transformation,
+        )
+
+        # Test in projection mode
+        params_projection = {
+            "epimodel": model,
+            "end_date": date(2024, 3, 31),
+            "projection": True,
+            "beta": 0.5,
+            "gamma": 0.1,
+        }
+        result_projection = wrapper(params_projection)
+
+        # Verify projection mode results include transformed compartment
+        if result_projection:  # If simulation succeeded
+            assert "I_plus_R_total" in result_projection
+            assert isinstance(result_projection["I_plus_R_total"], np.ndarray)
+
+        # Test in calibration mode
+        params_calibration = {
+            "epimodel": model,
+            "end_date": date(2024, 3, 31),
+            "projection": False,
+            "beta": 0.5,
+            "gamma": 0.1,
+        }
+        result_calibration = wrapper(params_calibration)
+
+        # Verify calibration mode still works (transformation applied before aggregation)
+        assert isinstance(result_calibration, dict)
+        assert "data" in result_calibration
+        assert isinstance(result_calibration["data"], np.ndarray)
+
+    def test_wrapper_with_failing_post_hoc_transformation(
+        self, base_model_config, mock_calibration, data_state, caplog
+    ):
+        """
+        Test that wrapper handles post-hoc transformation failures gracefully.
+
+        Tests:
+        - Exceptions in transformation are caught
+        - Non-transformed results are returned on failure
+        - Simulation continues despite transformation error
+        - Warning is logged
+        """
+        models, _ = create_model_collection(base_model_config, None)
+        model = models[0]
+
+        # Create a transformation function that always raises an exception
+        def failing_transformation(trajectory):
+            """Transformation that always fails."""
+            raise ValueError("Intentional test failure")
+
+        wrapper = make_simulate_wrapper(
+            basemodel=base_model_config,
+            calibration=mock_calibration,
+            observed_data=data_state,
+            intervention_types=[],
+            post_hoc_transformation=failing_transformation,
+        )
+
+        # Test in projection mode
+        params = {
+            "epimodel": model,
+            "end_date": date(2024, 3, 31),
+            "projection": True,
+            "beta": 0.5,
+            "gamma": 0.1,
+        }
+
+        # Should not raise exception - wrapper handles it gracefully
+        result = wrapper(params)
+
+        # Verify simulation completed (either succeeded or failed, but didn't crash)
+        assert isinstance(result, dict)
+
+        # Verify warning was logged
+        assert any("Post-hoc transformation failed" in record.message for record in caplog.records)
+
+        # If simulation succeeded, result should have standard keys (not transformed ones)
+        if result:  # Non-empty result means simulation succeeded
+            assert "date" in result
+            # Should NOT have any custom transformed compartments
+            assert "I_plus_R_total" not in result

--- a/tutorials/data/udf_examples.py
+++ b/tutorials/data/udf_examples.py
@@ -14,7 +14,7 @@ def udf_distance(data: Dict, simulation: Dict):
 
 def udf_transform(trajectory: Trajectory, context: dict | None = None):
     """
-    Dummy post-hoc transformation function that records a new compartment.
+    Dummy post-hoc transformation function that adds new compartments and transitions.
 
     Parameters
     ----------
@@ -33,10 +33,16 @@ def udf_transform(trajectory: Trajectory, context: dict | None = None):
     Returns
     -------
     Trajectory
-        Modified trajectory with additional compartment
+        Modified trajectory with additional compartments and transitions
 
     Examples
     --------
+    Adding new compartments:
+        >>> traj.compartments["Combined"] = traj.compartments["S_total"] + traj.compartments["I_total"]
+
+    Adding new transitions:
+        >>> traj.transitions["Total_flow"] = traj.transitions["S_to_I_total"] + traj.transitions["I_to_R_total"]
+
     Access calibrated parameters:
         >>> if context:
         ...     beta = context['params'].get('beta', 0)
@@ -45,17 +51,24 @@ def udf_transform(trajectory: Trajectory, context: dict | None = None):
         ...         pass
 
     Location-specific transformations:
-        >>> if context and context['location'] == 'US-CA':
+        >>> if context and context['location'] == 'United_States_California':
         ...     # California-specific transformation
         ...     pass
 
     Mode-dependent transformations:
         >>> if context and context['projection']:
-        ...     # Only add extra compartments in projection mode
+        ...     # Only add extra outputs in projection mode
         ...     pass
     """
     traj = copy.deepcopy(trajectory)
+
+    # Add new compartment (sum of existing compartments)
     traj.compartments["Dummy_S+L"] = traj.compartments["S_total"] + traj.compartments["L_total"]
+
+    # Add new transition (you can combine or derive from existing transitions)
+    # Note: Only add if the source transitions exist
+    if "S_to_I_total" in traj.transitions and "I_to_R_total" in traj.transitions:
+        traj.transitions["Dummy_total_flow"] = traj.transitions["S_to_I_total"] + traj.transitions["I_to_R_total"]
 
     # Example: Use context if provided
     if context:

--- a/tutorials/data/udf_examples.py
+++ b/tutorials/data/udf_examples.py
@@ -1,6 +1,7 @@
 ## udf_examples.py
 # Dummy examples for User-Defined Functions
 import copy
+from typing import Dict
 
 from epydemix.calibration import rmse
 from epydemix.model.simulation_output import Trajectory

--- a/tutorials/data/udf_examples.py
+++ b/tutorials/data/udf_examples.py
@@ -12,8 +12,67 @@ def udf_distance(data: Dict, simulation: Dict):
     return rmse(data, simulation)
 
 
-def udf_transform(trajectory: Trajectory):
-    """Dummy post-hoc transformation function that records a new compartment."""
+def udf_transform(trajectory: Trajectory, context: dict | None = None):
+    """
+    Dummy post-hoc transformation function that records a new compartment.
+
+    Parameters
+    ----------
+    trajectory : Trajectory
+        Simulation results from epydemix.simulate()
+    context : dict | None, optional
+        Simulation context containing:
+        - params: dict of calibrated parameters (e.g., beta, gamma, start_date)
+        - basemodel: BaseEpiModel configuration
+        - timespan: Timespan with actual simulation dates
+        - observed_data: DataFrame of observed data
+        - intervention_types: list of intervention type strings
+        - projection: bool indicating calibration vs projection mode
+        - location: str location/population name
+
+    Returns
+    -------
+    Trajectory
+        Modified trajectory with additional compartment
+
+    Examples
+    --------
+    Access calibrated parameters:
+        >>> if context:
+        ...     beta = context['params'].get('beta', 0)
+        ...     if beta > 0.5:
+        ...         # High transmission - apply different transformation
+        ...         pass
+
+    Location-specific transformations:
+        >>> if context and context['location'] == 'US-CA':
+        ...     # California-specific transformation
+        ...     pass
+
+    Mode-dependent transformations:
+        >>> if context and context['projection']:
+        ...     # Only add extra compartments in projection mode
+        ...     pass
+    """
     traj = copy.deepcopy(trajectory)
     traj.compartments["Dummy_S+L"] = traj.compartments["S_total"] + traj.compartments["L_total"]
+
+    # Example: Use context if provided
+    if context:
+        # Access calibrated parameters
+        beta = context["params"].get("beta", 0)
+
+        # Conditional logic based on parameter values
+        if beta > 0.5:
+            # High transmission - could add extra compartment or modify behavior
+            pass
+
+        # Access location
+        location = context["location"]
+
+        # Check mode
+        if context["projection"]:
+            # Projection-specific transformation
+            pass
+
     return traj


### PR DESCRIPTION
## Summary

Enables `post_hoc_transformation` UDFs to access model state during calibration via a new `context` keyword argument. This allows access to parameter values needed for prop_ed calibration.

Notes on prop_ed calibration:
- We introduce a new parameter `prop_ed_scaling_factor` as priror
- `prop_ed` would be calculated as `total hospitalization * prop_ed_scaling_factor`, using post-hoc transformation.
- For calibration, we compare `prop_ed` value to the surveillance prop ed data.

## Changes made

- Add `context` kwarg to `post_hoc_transformation`: Provides access to model state including `params`, `basemodel`, `timespan`, `observed_data`, `intervention_types`, `projection` flag, and `location`. Backward compatible - functions without `context` parameter still work.

- Add `PicklableFunction` wrapper: UDFs loaded from external scripts couldn't be unpickled because `dill` stored a reference to `user_defined_module` instead of the function code. `PicklableFunction` implements `__reduce__` protocol to store `(script_path, function_name)` and reload fresh on unpickle.

- Add `observed_location_format` in comparison schema: Auto-converts location codes (e.g., FIPS ↔ ISO) when loading calibration target data.

- Add `input_format` arggument (option) to `convert_location_name_format()`: Enables direct column lookup instead of auto-detection, more efficient for batch conversions.

- Bug fixes:
  - Fix empty array handling in `count_nans_at_start()`
  - Fix telemetry `capture_calibration()` keyword argument
  - Fix `hub_format_output` unbound variable when no hub format specified
  - Fix `covid19_format` attribute access in output generator