### PR TITLE
Fix AttributeError when flusight_format is None in output generation

### DIFF
--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -1388,7 +1388,7 @@ def generate_calibration_outputs(
                         meta_dict[colname].append(str(proj_params[p]))
 
         model_meta = pd.DataFrame(meta_dict)
-        if output.flusight_format.prop_ed:
+        if output.flusight_format and output.flusight_format.prop_ed:
             model_meta = model_meta.merge(rescaling_factors, on="population")
 
     ### Cleanup and return


### PR DESCRIPTION
## Problem
 Stage C (output generation) crashes with `AttributeError: 'NoneType' object has no attribute 'prop_ed'` when processing calibration results if the output configuration doesn't include a flusight_format section.

## Root Cause
Line 1391 in epymodelingsuite/dispatcher/output.py accessed `output.flusight_format.prop_ed` without first checking if `output.flusight_format` is None.

## Fix
Added None check before accessing .prop_ed attribute