### PR TITLE
Fix UserDefinedFunction serialization in telemetry

### DIFF
--- a/epymodelingsuite/telemetry/core.py
+++ b/epymodelingsuite/telemetry/core.py
@@ -32,6 +32,28 @@ def _get_package_version() -> str:
         return "unknown"
 
 
+def _serialize_distance_function(distance_func: str | object) -> str:
+    """Convert distance function to JSON-serializable string.
+
+    Parameters
+    ----------
+    distance_func : str | object
+        Distance function (str or UserDefinedFunction)
+
+    Returns
+    -------
+    str
+        String representation of the distance function
+    """
+    if isinstance(distance_func, str):
+        return distance_func
+    # Check if it's a UserDefinedFunction by checking for user_function_name attribute
+    if hasattr(distance_func, "user_function_name"):
+        return f"user_defined:{distance_func.user_function_name}"
+    # Fallback to string conversion
+    return str(distance_func)
+
+
 class ExecutionTelemetry:
     """Track execution metrics and telemetry for dispatcher workflows.
 
@@ -350,7 +372,9 @@ class ExecutionTelemetry:
             if "num_generations" in calibration_strategy.options:
                 model_data["calibration"]["num_generations"] = calibration_strategy.options["num_generations"]
             if "distance_function" in calibration_strategy.options:
-                model_data["calibration"]["distance_function"] = calibration_strategy.options["distance_function"]
+                model_data["calibration"]["distance_function"] = _serialize_distance_function(
+                    calibration_strategy.options["distance_function"]
+                )
 
         if error:
             model_data["error"] = error
@@ -413,7 +437,9 @@ class ExecutionTelemetry:
             if "num_generations" in calibration_strategy.options:
                 model_data["calibration"]["num_generations"] = calibration_strategy.options["num_generations"]
             if "distance_function" in calibration_strategy.options:
-                model_data["calibration"]["distance_function"] = calibration_strategy.options["distance_function"]
+                model_data["calibration"]["distance_function"] = _serialize_distance_function(
+                    calibration_strategy.options["distance_function"]
+                )
 
         # Record projection info
         projection_info = self._extract_projection_info(output.results, n_trajectories)

--- a/epymodelingsuite/telemetry/extractors.py
+++ b/epymodelingsuite/telemetry/extractors.py
@@ -67,8 +67,13 @@ def extract_builder_metadata(
             str(fitting_window.start_date),
             str(fitting_window.end_date),
         )
-        # Extract distance function
-        metadata["distance_function"] = calibration_config.modelset.calibration.distance_function
+        # Extract distance function (convert UserDefinedFunction to string representation)
+        distance_func = calibration_config.modelset.calibration.distance_function
+        if isinstance(distance_func, str):
+            metadata["distance_function"] = distance_func
+        else:
+            # UserDefinedFunction - store as string representation
+            metadata["distance_function"] = f"user_defined:{distance_func.user_function_name}"
 
     return metadata
 


### PR DESCRIPTION
Fixes `TypeError: Object of type UserDefinedFunction is not JSON serializable` when saving telemetry summaries.

## Changes
- Added `_serialize_distance_function()` helper to convert `UserDefinedFunction` objects to `"user_defined:<function_name>"` strings
- Updated telemetry extraction to serialize `distance_function` fields before JSON encoding