### PR TITLE
Fix prop_ed_calibration_window location code and merge issues

### DIFF
--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -558,6 +558,12 @@ def prop_ed_calibration_window(
     # Read surveillance file from config
     obs_ed_df = read_surveillance_from_config(obs_ed)
 
+    # TODO: Use ISO in future
+    # Convert location codes to FIPS format to match pred_hosp
+    obs_ed_df[obs_ed.location_column] = obs_ed_df[obs_ed.location_column].apply(
+        lambda x: convert_location_name_format(x, "FIPS")
+    )
+
     # Resolve fitting windows
     fit_end = calibration_quantiles.date.max()
     fit_start = fit_end - timedelta(weeks=num_fit_weeks - 1)


### PR DESCRIPTION
## Summary
- Fixes `KeyError: 'US'` in prop_ed output generation
- Converts ED surveillance location codes to FIPS format
- Fixes dataframe column assignment bug in merge operation

## Changes
1. Added location code conversion to FIPS format (matching `prop_ed_surveillance_window` pattern)
2. Fixed pandas SettingWithCopyWarning by using `.copy()` on filtered dataframe
3. Changed column assignment from attribute to bracket notation for proper merge keys

## Root Cause
The merge operation was failing due to:
- Location code format mismatch (ISO vs FIPS)
- Improper column assignment on dataframe view causing merge key errors