### PR TITLE
Update ED visit data fetching: fix query + add DL script

### DIFF
--- a/epymodelingsuite/utils/data.py
+++ b/epymodelingsuite/utils/data.py
@@ -218,6 +218,9 @@ def fetch_nssp_edvisits(
         of all ED patient visits for the specified geography that were observed for the given week from
         data submitted to the National Syndromic Surveillance Program (NSSP).
 
+        Dataset ID: rdmq-nq56
+        https://data.cdc.gov/Public-Health-Surveillance/NSSP-Emergency-Department-Visit-Trajectories-by-St/rdmq-nq56/about_data
+
     Data Field
         Uses `percent_visits_influenza`
 
@@ -233,15 +236,16 @@ def fetch_nssp_edvisits(
     client = Socrata("data.cdc.gov", None)
 
     # Build query
+    # Filter for state-level data (county='All') in the API call, because the data is granular than hospitalization data. If we don't add filtering clause here, recent data points would not be included since hitting the 100,000 limit.
+    base_where = "county='All'"
     if query_start_date:
-        where_clause = f"week_end >= '{query_start_date}'"
+        where_clause = f"{base_where} AND week_end >= '{query_start_date}'"
         results = client.get(dataset_id, where=where_clause, limit=100000)
     else:
-        results = client.get(dataset_id, limit=100000)
+        results = client.get(dataset_id, where=base_where, limit=100000)
 
     # Convert to pandas DataFrame
     data = pd.DataFrame.from_records(results)
-    data = data[data.county == "All"]
     data = data[["week_end", "geography", "percent_visits_influenza"]]
 
     # Process dates and epiweeks
@@ -276,7 +280,7 @@ def fetch_nssp_edvisits(
     # Filter out territories and HHS regions (keep only states, DC, and USA)
     territories = ["AS", "GU", "MP", "PR", "VI"]
     data = data[data["location_iso"].notna()]
-    data = data[~data["location"].isin(territories)]
+    data = data[~data["abbreviation"].isin(territories)]
 
     # Select final columns
     data = data[["location_iso", "location_code", "target_end_date", "epiweek", "prop_ed_visits"]]

--- a/scripts/download_edvisit_data.py
+++ b/scripts/download_edvisit_data.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Script to download NSSP ED visits data from CDC.
+
+Example usage:
+    # Download with defaults (starts from 2024-01-01, saves to flu_prop-ed_25.csv)
+    python download_edvisit_data.py
+
+    # Download from a specific date
+    python download_edvisit_data.py --start-date 2024-10-01
+
+    # Specify custom output file
+    python download_edvisit_data.py --output my_edvisit_data.csv
+
+    # All options specified
+    python download_edvisit_data.py --start-date 2024-01-01 --output flu_prop-ed_25.csv
+"""
+
+import argparse
+from pathlib import Path
+
+from epymodelingsuite.utils.data import fetch_nssp_edvisits
+
+
+def main():
+    """Download NSSP ED visits data."""
+    parser = argparse.ArgumentParser(
+        description="Download NSSP ED visits data from CDC",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--start-date",
+        type=str,
+        default="2024-01-01",
+        help="Start date for data download (format: YYYY-MM-DD). Default: 2024-01-01",
+    )
+
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="flu_prop-ed_25.csv",
+        help="Output CSV file path. Default: flu_prop-ed_25.csv",
+    )
+
+    args = parser.parse_args()
+
+    # Create output directory if it doesn't exist
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print("Downloading NSSP ED visits data...")
+    print(f"  Start date: {args.start_date}")
+    print(f"  Output file: {args.output}")
+
+    # Fetch data
+    df = fetch_nssp_edvisits(
+        query_start_date=args.start_date,
+        save_path=args.output,
+    )
+
+    print("\nDownload complete!")
+    print(f"  Total records: {len(df)}")
+    print(f"  Date range: {df['target_end_date'].min()} to {df['target_end_date'].max()}")
+    print(f"  Locations: {df['location_iso'].nunique()}")
+    print(f"  Saved to: {args.output}")
+
+    # Show preview
+    print("\nFirst few rows:")
+    print(df.head())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary
Fixed a bug where recent ED visits data were not included.

### Problem
ED data was missing recent datapoints because the API's 100,000-row limit was being hit by older records before fetching recent data. (ED dataset has higher granularity than hospitalization because it includes county-level data).

### Changes
- Updated `fetch_nssp_edvisits`
  - Added `county='All'` filter to Socrata API query to fetch only state-level aggregates
  - Added dataset ID and CDC data link to documentation
  - Fixed territory filtering bug (changed from `location` to `abbreviation`)
- Added `scripts/download_edvisit_data.py`