### PR TITLE
Support prop ED forecasts from UDF transitions + graceful error handling

### DIFF
--- a/epymodelingsuite/builders/orchestrators.py
+++ b/epymodelingsuite/builders/orchestrators.py
@@ -944,6 +944,12 @@ def make_scenario_projection_simulate_wrappers(
     Construct a list of simulate_wrappers from basemodel and calibration config, which differ only
     in the overrides
 
+    .. deprecated::
+        This function is deprecated and will be removed in a future version.
+        Use the dispatcher workflow (dispatch_builder/dispatch_runner) instead.
+        This function uses hardcoded "geo_value" for location column name instead of
+        reading from calibration_config.comparison[0].observed_location_column.
+
     Parameters
     ----------
         basemodel_config: BasemodelConfig
@@ -965,6 +971,15 @@ def make_scenario_projection_simulate_wrappers(
         list[Callable]
             A list of simulate-wrapper callables (one per location).
     """
+    import warnings
+
+    warnings.warn(
+        "make_scenario_projection_simulate_wrappers is deprecated and will be removed in a future version. "
+        "Use the dispatcher workflow (dispatch_builder/dispatch_runner) instead. "
+        "This function uses hardcoded 'geo_value' for location column instead of reading from config.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     basemodel = copy.deepcopy(basemodel_config.model)
     modelset = calibration_config.modelset
     calibration = modelset.calibration

--- a/epymodelingsuite/builders/utils.py
+++ b/epymodelingsuite/builders/utils.py
@@ -6,7 +6,7 @@ from ..schema.calibration import CalibrationConfig
 from ..utils import convert_location_name_format
 
 
-def get_data_in_window(data: pd.DataFrame, calibration: CalibrationConfig) -> pd.DataFrame:
+def get_data_in_window(data: pd.DataFrame, calibration: CalibrationConfig, sort: bool = True) -> pd.DataFrame:
     """
     Get data within a specified time window.
 
@@ -16,11 +16,14 @@ def get_data_in_window(data: pd.DataFrame, calibration: CalibrationConfig) -> pd
         The full dataset to filter.
     calibration : CalibrationConfig
         Calibration configuration containing fitting window dates.
+    sort : bool, optional
+        If True, sort the filtered data by date in ascending order (oldest to newest).
+        Default is True to ensure consistent ordering for ABC distance functions.
 
     Returns
     -------
     pd.DataFrame
-        Filtered data within the specified time window.
+        Filtered data within the specified time window, optionally sorted by date.
     """
     window_start = calibration.fitting_window.start_date
     window_end = calibration.fitting_window.end_date
@@ -29,7 +32,12 @@ def get_data_in_window(data: pd.DataFrame, calibration: CalibrationConfig) -> pd
     date_col = pd.to_datetime(data[date_col_name]).dt.date
 
     mask = (date_col >= window_start) & (date_col <= window_end)
-    return data.loc[mask]
+    filtered = data.loc[mask]
+
+    if sort:
+        filtered = filtered.sort_values(by=date_col_name).reset_index(drop=True)
+
+    return filtered
 
 
 def get_data_in_location(

--- a/epymodelingsuite/dispatcher/builder.py
+++ b/epymodelingsuite/dispatcher/builder.py
@@ -444,14 +444,18 @@ def build_calibration(
 
     logger.info("BUILDER: setting up ABCSamplers...")
 
+    # Load observed data from CSV
     observed_raw = pd.read_csv(calibration.observed_data_path)
+    # Filter to fitting window and sort by date (oldest to newest) for consistent ABC distance calculations
     observed_in_window = get_data_in_window(observed_raw, calibration)
     calibrators = []
     location_column = calibration.comparison[0].observed_location_column
     location_format = calibration.comparison[0].observed_location_format
 
     for model in models:
-        observed_data = get_data_in_location(observed_in_window, model.population.name, location_column, location_format)
+        observed_data = get_data_in_location(
+            observed_in_window, model.population.name, location_column, location_format
+        )
         vax_state = (
             get_data_in_location(earliest_vax, model.population.name, "location") if earliest_vax is not None else None
         )

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -1115,59 +1115,64 @@ def generate_calibration_outputs(
                 )
                 continue
 
-            transition_columns = [c for c in quan_df.columns if "_to_" in c]
+            try:
+                transition_columns = [c for c in quan_df.columns if "_to_" in c]
 
-            # Compartments
-            if output.quantiles.compartments:
-                if hasattr(output.quantiles.compartments, "__len__"):
-                    # Filter for explicitly requested compartments
-                    try:
-                        columns_to_select = ["date", "quantile"]
-                        columns_to_select.extend(output.quantiles.compartments)
-                        quanc_df = quan_df[columns_to_select].copy()
-                    except KeyError as e:
-                        warnings.add(
-                            f"OUTPUT GENERATOR: Exception occured selecting compartment quantiles, returning all compartments: {e}"
-                        )
+                # Compartments
+                if output.quantiles.compartments:
+                    if hasattr(output.quantiles.compartments, "__len__"):
+                        # Filter for explicitly requested compartments
+                        try:
+                            columns_to_select = ["date", "quantile"]
+                            columns_to_select.extend(output.quantiles.compartments)
+                            quanc_df = quan_df[columns_to_select].copy()
+                        except KeyError as e:
+                            warnings.add(
+                                f"OUTPUT GENERATOR: Exception occured selecting compartment quantiles, returning all compartments: {e}"
+                            )
+                            # Use all compartments, filter out transitions
+                            quanc_df = quan_df.copy()
+                            quanc_df.drop(columns=transition_columns, inplace=True)
+                    else:
                         # Use all compartments, filter out transitions
                         quanc_df = quan_df.copy()
                         quanc_df.drop(columns=transition_columns, inplace=True)
-                else:
-                    # Use all compartments, filter out transitions
-                    quanc_df = quan_df.copy()
-                    quanc_df.drop(columns=transition_columns, inplace=True)
-                quanc_df.insert(0, "primary_id", calibration.primary_id)
-                quanc_df.insert(1, "seed", calibration.seed)
-                quanc_df.insert(2, "population", calibration.population)
-                quantiles_projection_compartments_list.append(quanc_df)
+                    quanc_df.insert(0, "primary_id", calibration.primary_id)
+                    quanc_df.insert(1, "seed", calibration.seed)
+                    quanc_df.insert(2, "population", calibration.population)
+                    quantiles_projection_compartments_list.append(quanc_df)
 
-            # Transitions
-            if output.quantiles.transitions:
-                if hasattr(output.quantiles.transitions, "__len__"):
-                    # Filter for explicitly requested transitions
-                    try:
-                        columns_to_select = ["date", "quantile"]
-                        columns_to_select.extend(output.quantiles.transitions)
-                        quant_df = quan_df[columns_to_select].copy()
-                    except Exception as e:
-                        warnings.add(
-                            f"OUTPUT GENERATOR: Exception occured selecting compartment quantiles, returning all transitions: {e}"
-                        )
+                # Transitions
+                if output.quantiles.transitions:
+                    if hasattr(output.quantiles.transitions, "__len__"):
+                        # Filter for explicitly requested transitions
+                        try:
+                            columns_to_select = ["date", "quantile"]
+                            columns_to_select.extend(output.quantiles.transitions)
+                            quant_df = quan_df[columns_to_select].copy()
+                        except Exception as e:
+                            warnings.add(
+                                f"OUTPUT GENERATOR: Exception occured selecting compartment quantiles, returning all transitions: {e}"
+                            )
+                            # Use all transitions, filter out compartments
+                            # TODO: add target prediction data column name below
+                            columns_to_select = ["date", "quantile"]
+                            columns_to_select.extend(transition_columns)
+                            quant_df = quan_df[columns_to_select].copy()
+                    else:
                         # Use all transitions, filter out compartments
                         # TODO: add target prediction data column name below
                         columns_to_select = ["date", "quantile"]
                         columns_to_select.extend(transition_columns)
                         quant_df = quan_df[columns_to_select].copy()
-                else:
-                    # Use all transitions, filter out compartments
-                    # TODO: add target prediction data column name below
-                    columns_to_select = ["date", "quantile"]
-                    columns_to_select.extend(transition_columns)
-                    quant_df = quan_df[columns_to_select].copy()
-                quant_df.insert(0, "primary_id", calibration.primary_id)
-                quant_df.insert(1, "seed", calibration.seed)
-                quant_df.insert(2, "population", calibration.population)
-                quantiles_projection_transitions_list.append(quant_df)
+                    quant_df.insert(0, "primary_id", calibration.primary_id)
+                    quant_df.insert(1, "seed", calibration.seed)
+                    quant_df.insert(2, "population", calibration.population)
+                    quantiles_projection_transitions_list.append(quant_df)
+            except Exception as e:
+                warnings.add(
+                    f"OUTPUT GENERATOR: Exception occurred processing quantile outputs for model with primary_id={calibration.primary_id}, continuing to next model. Message: {e}"
+                )
 
     quantiles_projection_compartments = (
         pd.concat(quantiles_projection_compartments_list, ignore_index=True)

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -1489,7 +1489,7 @@ def generate_calibration_outputs(
                 else:
                     meta_dict["start_date"].append(None)
                     meta_dict["end_date"].append(None)
-            except (KeyError, IndexError, AttributeError, TypeError) as e:
+            except (KeyError, IndexError, AttributeError, TypeError, ValueError) as e:
                 logger.warning("Failed to extract projection window dates: %s", e)
                 meta_dict["start_date"].append(None)
                 meta_dict["end_date"].append(None)

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -619,6 +619,8 @@ def make_prop_ed_flusightforecast(
     config: FlusightPropED,
     surveillance: dict[str, ObservedValuesConfig],
     calibration_quantiles: pd.DataFrame | None = None,
+    projection_quantiles: pd.DataFrame | None = None,
+    reference_date: date | None = None,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """
     Create FluSight prop ed forecasts from hosp forecast and surveillance data.
@@ -633,6 +635,10 @@ def make_prop_ed_flusightforecast(
         Dictionary containing configurations for surveillance data (from output.options.surveillance)
     calibration_quantiles: pd.DataFrame | None
         Quantiles from the calibration fitting window (if config.strategy is 'calibration_window')
+    projection_quantiles: pd.DataFrame | None
+        Quantiles from the projection phase (if config.strategy is 'transition')
+    reference_date: date | None
+        Reference date for calculating horizons (required if pred_hosp is empty)
 
     Returns
     -------
@@ -666,6 +672,76 @@ def make_prop_ed_flusightforecast(
             return prop_ed_calibration_window(
                 pred_hosp, surveillance[config.ed_source], calibration_quantiles, config.num_fit_weeks
             )
+        case "transition":
+            # Ensure projection_quantiles is provided
+            if projection_quantiles is None or projection_quantiles.empty:
+                msg = "Strategy 'transition' requires projection_quantiles, but not received."
+                raise ValueError(msg)
+
+            # Ensure transition_name exists in projection_quantiles
+            if config.transition_name not in projection_quantiles.columns:
+                msg = f"Transition '{config.transition_name}' not found in projection_quantiles. Available columns: {list(projection_quantiles.columns)}"
+                raise ValueError(msg)
+
+            # Format the transition quantiles into FluSight format
+            formatted = copy.deepcopy(projection_quantiles)
+
+            # Horizons required for quantile outputs
+            flusight_horizons = range(-1, 4)
+
+            # Get the reference date from parameter or pred_hosp
+            if reference_date is None:
+                if not pred_hosp.empty and "reference_date" in pred_hosp.columns:
+                    reference_date = pd.to_datetime(pred_hosp.reference_date.iloc[0]).date()
+                else:
+                    msg = (
+                        "Cannot determine reference_date: must provide reference_date parameter or non-empty pred_hosp"
+                    )
+                    raise ValueError(msg)
+
+            # Create horizon column and filter for appropriate horizons
+            formatted.insert(
+                0,
+                "horizon",
+                (formatted.date - pd.to_datetime(reference_date))
+                .apply(lambda x: x / np.timedelta64(1, "W"))
+                .astype(int),
+            )
+            formatted = formatted[formatted.horizon.isin(flusight_horizons)]
+
+            # Rename and format columns
+            formatted.rename(
+                columns={"date": "target_end_date", config.transition_name: "value", "quantile": "output_type_id"},
+                inplace=True,
+            )
+            formatted.insert(2, "output_type", "quantile")
+            formatted.insert(2, "target", "wk inc flu prop ed visits")
+            formatted.target_end_date = formatted.target_end_date.apply(lambda x: x.date() if hasattr(x, "date") else x)
+
+            # Add location and reference_date columns
+            formatted.insert(0, "reference_date", reference_date)
+            # Convert population to FIPS format for each row
+            formatted.insert(
+                0, "location", formatted.population.apply(lambda x: convert_location_name_format(x, "FIPS"))
+            )
+
+            # Select only the columns we need for FluSight format
+            formatted = formatted[
+                [
+                    "location",
+                    "reference_date",
+                    "horizon",
+                    "target",
+                    "output_type",
+                    "output_type_id",
+                    "target_end_date",
+                    "value",
+                ]
+            ]
+
+            # Return formatted df and empty rescaling_factors dataframe
+            rescaling_factors = pd.DataFrame()
+            return formatted, rescaling_factors
         case _:
             raise ValueError(f"Received undefined/unimplemented strategy {config.strategy}")
 
@@ -1228,30 +1304,32 @@ def generate_calibration_outputs(
     if output.flusight_format:
         logger.info("Generating FluSight forecast hub outputs")
 
-        # Quantile forecasts
-        logger.info("  - Generating FluSight quantile forecasts")
-        for calibration in calibrations:
-            try:
-                # FRAGILE: the name 'hospitalizations' is user-supplied in the modelset as the column to look for in the surveillance data.
-                quanf_df = calibration.results.get_projection_quantiles(
-                    quantiles=get_flusight_quantiles(), variables=["date", "quantile", "hospitalizations"]
-                )
-            except ValueError:
-                warnings.add(
-                    f"OUTPUT GENERATOR: failed to obtain projection quantiles for model with primary_id={calibration.primary_id}, continuing to next model."
-                )
-                continue
-            quanf_df = format_quantiles_flusightforecast(quanf_df, output.flusight_format.reference_date)
-            quanf_df.insert(0, "reference_date", output.flusight_format.reference_date)
-            quanf_df.insert(0, "location", convert_location_name_format(calibration.population, "FIPS"))
-            hub_format_output_list.append(quanf_df)
+        # Quantile forecasts (hospitalizations)
+        if output.flusight_format.hospitalizations:
+            logger.info("  - Generating FluSight quantile forecasts (hospitalizations)")
+            for calibration in calibrations:
+                try:
+                    # FRAGILE: the name 'hospitalizations' is user-supplied in the modelset as the column to look for in the surveillance data.
+                    quanf_df = calibration.results.get_projection_quantiles(
+                        quantiles=get_flusight_quantiles(), variables=["date", "quantile", "hospitalizations"]
+                    )
+                except ValueError:
+                    warnings.add(
+                        f"OUTPUT GENERATOR: failed to obtain projection quantiles for model with primary_id={calibration.primary_id}, continuing to next model."
+                    )
+                    continue
+                quanf_df = format_quantiles_flusightforecast(quanf_df, output.flusight_format.reference_date)
+                quanf_df.insert(0, "reference_date", output.flusight_format.reference_date)
+                quanf_df.insert(0, "location", convert_location_name_format(calibration.population, "FIPS"))
+                hub_format_output_list.append(quanf_df)
 
         # Prop ED forecasts
         if output.flusight_format.prop_ed:
-            # Get surveillance source configuration
-            if not output.options or not output.options.surveillance:
-                msg = "prop_ed specified but no surveillance sources defined in output.options.surveillance"
-                raise ValueError(msg)
+            # Get surveillance source configuration (not needed for transition strategy)
+            if output.flusight_format.prop_ed.strategy != "transition":
+                if not output.options or not output.options.surveillance:
+                    msg = "prop_ed specified but no surveillance sources defined in output.options.surveillance"
+                    raise ValueError(msg)
 
             # Make calibration quantiles with flusight required quantiles if using calibration_window strategy
             quantiles_calibration_flusight_list = []
@@ -1270,9 +1348,30 @@ def generate_calibration_outputs(
                             f"OUTPUT GENERATOR: Exception occured obtaining calibration quantiles for model with primary_id={calibration.primary_id} during prop_ed forecast generation, continuing. Message: {e}"
                         )
 
+            # Make projection quantiles with transition if using transition strategy
+            quantiles_projection_flusight_list = []
+            if output.flusight_format.prop_ed.strategy == "transition":
+                transition_name = output.flusight_format.prop_ed.transition_name
+                for calibration in calibrations:
+                    try:
+                        quanproj_df = calibration.results.get_projection_quantiles(
+                            quantiles=get_flusight_quantiles(), variables=["date", "quantile", transition_name]
+                        )
+                        quanproj_df.insert(0, "primary_id", calibration.primary_id)
+                        quanproj_df.insert(1, "seed", calibration.seed)
+                        quanproj_df.insert(2, "population", calibration.population)
+                        quantiles_projection_flusight_list.append(quanproj_df)
+                    except Exception as e:
+                        warnings.add(
+                            f"OUTPUT GENERATOR: Exception occured obtaining projection quantiles for transition '{transition_name}' for model with primary_id={calibration.primary_id} during prop_ed forecast generation, continuing. Message: {e}"
+                        )
+
             # Collect data and generate prop ed forecast
             quantiles_calibration_flusight = (
                 pd.concat(quantiles_calibration_flusight_list) if quantiles_calibration_flusight_list else None
+            )
+            quantiles_projection_flusight = (
+                pd.concat(quantiles_projection_flusight_list) if quantiles_projection_flusight_list else None
             )
             hosp_forecast = (
                 pd.concat(hub_format_output_list, ignore_index=True) if hub_format_output_list else pd.DataFrame()
@@ -1280,13 +1379,15 @@ def generate_calibration_outputs(
             prop_ed_df, rescaling_factors = make_prop_ed_flusightforecast(
                 hosp_forecast,
                 output.flusight_format.prop_ed,
-                output.options.surveillance,
+                output.options.surveillance if output.options else {},
                 quantiles_calibration_flusight,
+                quantiles_projection_flusight,
+                output.flusight_format.reference_date,
             )
             hub_format_output_list.append(prop_ed_df)
 
-        # Rate-trend forecasts
-        if output.flusight_format.rate_trends_source:
+        # Rate-trend forecasts (only if hospitalizations is enabled)
+        if output.flusight_format.rate_trends_source and output.flusight_format.hospitalizations:
             logger.info("  - Generating FluSight rate-trend forecasts")
             # Get surveillance source configuration
             if not output.options or not output.options.surveillance:

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -479,19 +479,20 @@ def prop_ed_surveillance_window(
     # Read surveillance files from config
     obs_ed_df = read_surveillance_from_config(obs_ed)
     obs_hosp_df = read_surveillance_from_config(obs_hosp)
-    obs_hosp_df[obs_hosp.location_column] = obs_hosp_df[obs_hosp.location_column].apply(
-        lambda x: convert_location_name_format(x, "FIPS")
-    )
 
     # Create forecast
     prop_ed_list = []
     r_dict = defaultdict(list)
     for loc in pred_hosp.location.unique():
+        # Convert FIPS location to surveillance data formats for filtering
+        loc_hosp = convert_location_name_format(loc, obs_hosp.location_format)
+        loc_ed = convert_location_name_format(loc, obs_ed.location_format)
+
         # Filter forecasts and observations
         filt_pred_hosp = pred_hosp[(pred_hosp.location == loc) & (pred_hosp.output_type == "quantile")].copy(deep=True)
         filt_obs_hosp = (
             obs_hosp_df[
-                (obs_hosp_df[obs_hosp.location_column] == loc)
+                (obs_hosp_df[obs_hosp.location_column] == loc_hosp)
                 & (obs_hosp_df[obs_hosp.date_column] >= pd.to_datetime(fit_start))
                 & (obs_hosp_df[obs_hosp.date_column] < pd.to_datetime(fit_end))
             ]
@@ -500,7 +501,7 @@ def prop_ed_surveillance_window(
         )
         filt_obs_ed = (
             obs_ed_df[
-                (obs_ed_df[obs_ed.location_column] == loc)
+                (obs_ed_df[obs_ed.location_column] == loc_ed)
                 & (obs_ed_df[obs_ed.date_column] >= pd.to_datetime(fit_start))
                 & (obs_ed_df[obs_ed.date_column] < pd.to_datetime(fit_end))
             ]
@@ -575,11 +576,14 @@ def prop_ed_calibration_window(
     prop_ed_list = []
     r_dict = defaultdict(list)
     for loc in pred_hosp.location.unique():
+        # Convert FIPS location to surveillance data format for filtering
+        loc_ed = convert_location_name_format(loc, obs_ed.location_format)
+
         # Filter forecasts and observations
         filt_pred_hosp = pred_hosp[(pred_hosp.location == loc) & (pred_hosp.output_type == "quantile")].copy(deep=True)
         filt_obs_ed = (
             obs_ed_df[
-                (obs_ed_df[obs_ed.location_column] == loc)
+                (obs_ed_df[obs_ed.location_column] == loc_ed)
                 & (obs_ed_df[obs_ed.date_column] >= fit_start)
                 & (obs_ed_df[obs_ed.date_column] <= fit_end)
             ]
@@ -1310,10 +1314,9 @@ def generate_calibration_outputs(
                     continue
 
                 # Filter surveillance for location
-                surv = surveillance[
-                    surveillance[source_config.location_column]
-                    == convert_location_name_format(calibration.population, "ISO")
-                ]
+                # Convert calibration population to surveillance data's location format
+                target_location = convert_location_name_format(calibration.population, source_config.location_format)
+                surv = surveillance[surveillance[source_config.location_column] == target_location]
                 surv = surv.drop(columns=source_config.location_column).rename(
                     columns={
                         source_config.date_column: "date",

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -1457,6 +1457,15 @@ def generate_calibration_outputs(
     if output.model_meta:
         logger.info("Generating model metadata outputs")
         for calibration in calibrations:
+            # Skip calibrations without projections (failed calibrations)
+            if not calibration.results.projections:
+                logger.warning(
+                    "Skipping model metadata for primary_id=%s (%s) - no projections available",
+                    calibration.primary_id,
+                    calibration.population,
+                )
+                continue
+
             meta_dict["primary_id"].append(calibration.primary_id)
             meta_dict["seed"].append(calibration.seed)
             meta_dict["delta_t"].append(calibration.delta_t)

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -1504,7 +1504,7 @@ def generate_calibration_outputs(
                         meta_dict[colname].append(str(proj_params[p]))
 
         model_meta = pd.DataFrame(meta_dict)
-        if output.flusight_format and output.flusight_format.prop_ed:
+        if output.flusight_format and output.flusight_format.prop_ed and not rescaling_factors.empty:
             model_meta = model_meta.merge(rescaling_factors, on="population")
 
     ### Cleanup and return

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -1301,6 +1301,7 @@ def generate_calibration_outputs(
     ### Hub Formats
 
     # FluSight Forecast Hub
+    logger.info(f"DEBUG: output.flusight_format = {output.flusight_format}")
     if output.flusight_format:
         logger.info("Generating FluSight forecast hub outputs")
 

--- a/epymodelingsuite/schema/output.py
+++ b/epymodelingsuite/schema/output.py
@@ -126,24 +126,32 @@ class ObservedValuesConfig(BaseModel):
         return v
 
 
-class RescaleStrategyEnum(str, Enum):
+class PropEDStrategyEnum(str, Enum):
     """
-    Strategy for rescaling hospitalization surveillance/forecast.
+    Strategy for generating prop ED forecasts.
 
-    Rescaling factors are obtained by minimizing MSE according to strategy, then applied to a hosipitalization forecast to create a prop ed forecast:
-    surveillance_window - fit using observed hospitalizations against observed ED visits over a fitting window
-    calibration_window - fit using median calibration quantile against observed ED visits over a fitting window anchored at the end of the calibration fitting window
+    surveillance_window - fit rescaling factor using observed hospitalizations against observed ED visits over a fitting window
+    calibration_window - fit rescaling factor using median calibration quantile against observed ED visits over a fitting window anchored at the end of the calibration fitting window
+    transition - use a transition directly (e.g., ed_prop) computed in UDF, no rescaling needed
     """
 
     surveillance_window = "surveillance_window"
     calibration_window = "calibration_window"
+    transition = "transition"
 
 
 class FlusightPropED(BaseModel):
     """Specifications for generating the wk_inc_flu_prop_ed_visits target forecasts."""
 
-    strategy: RescaleStrategyEnum = Field(description="Strategy for rescaling hospitalization surveillance/forecast.")
-    ed_source: str = Field(description="Reference name for 'wk inc flu prop ed visits' surveillance data.")
+    strategy: PropEDStrategyEnum = Field(description="Strategy for generating prop ED forecasts.")
+    transition_name: str | None = Field(
+        None,
+        description="Name of transition to use for prop ED forecasts (required iff using 'transition' strategy).",
+    )
+    ed_source: str | None = Field(
+        None,
+        description="Reference name for 'wk inc flu prop ed visits' surveillance data (required for rescaling strategies).",
+    )
     hosp_source: str | None = Field(
         None,
         description="Name of hospitalization surveillance source from output.options.surveillance (iff using 'surveillance_window' strategy).",
@@ -164,9 +172,11 @@ class FlusightPropED(BaseModel):
     def check_strategy_args(self):
         """Ensure appropriate arguments are provided for each strategy."""
         match self.strategy:
-            case RescaleStrategyEnum.surveillance_window:
-                # This should be impossible
-                assert self.ed_source, "Missing 'ed_source'."
+            case PropEDStrategyEnum.surveillance_window:
+                # Ensure ed_source present
+                if not self.ed_source:
+                    msg = "Prop ED strategy 'surveillance_window' requires field 'ed_source'"
+                    raise ValueError(msg)
                 # Ensure source present
                 if not self.hosp_source:
                     msg = "Prop ED strategy 'surveillance_window' requires field 'hosp_source'"
@@ -178,13 +188,18 @@ class FlusightPropED(BaseModel):
                 if not self.fit_start <= self.fit_end:
                     msg = f"Received fit_start: {self.fit_start} > fit_end: {self.fit_end}"
                     raise ValueError(msg)
-                # Warn unused field
+                # Warn unused fields
                 if self.num_fit_weeks is not None:
                     msg = "Received unused 'num_fit_weeks' with prop ED strategy 'surveillance_window'; ignoring."
                     logger.warning(msg)
-            case RescaleStrategyEnum.calibration_window:
-                # This should be impossible
-                assert self.ed_source, "Missing 'ed_source'."
+                if self.transition_name is not None:
+                    msg = "Received unused 'transition_name' with prop ED strategy 'surveillance_window'; ignoring."
+                    logger.warning(msg)
+            case PropEDStrategyEnum.calibration_window:
+                # Ensure ed_source present
+                if not self.ed_source:
+                    msg = "Prop ED strategy 'calibration_window' requires field 'ed_source'"
+                    raise ValueError(msg)
                 # Ensure window specified
                 if self.num_fit_weeks is None:
                     msg = "Prop ED strategy 'calibration_window' requires field 'num_fit_weeks'"
@@ -197,10 +212,38 @@ class FlusightPropED(BaseModel):
                     logger.warning(msg)
                 if self.hosp_source:
                     msg = "Received unused 'hosp_source' with prop ED strategy 'calibration_window'; ignoring."
+                    logger.warning(msg)
+                if self.transition_name is not None:
+                    msg = "Received unused 'transition_name' with prop ED strategy 'calibration_window'; ignoring."
+                    logger.warning(msg)
+            case PropEDStrategyEnum.transition:
+                # Ensure transition_name present
+                if not self.transition_name:
+                    msg = "Prop ED strategy 'transition' requires field 'transition_name'"
+                    raise ValueError(msg)
+                # Warn unused fields
+                if self.ed_source is not None:
+                    msg = "Received unused 'ed_source' with prop ED strategy 'transition'; ignoring."
+                    logger.warning(msg)
+                if self.hosp_source is not None:
+                    msg = "Received unused 'hosp_source' with prop ED strategy 'transition'; ignoring."
+                    logger.warning(msg)
+                if bool(self.fit_start) or bool(self.fit_end):
+                    msg = "Received unused 'fit_start' or 'fit_end' with prop ED strategy 'transition'; ignoring."
+                    logger.warning(msg)
+                if self.num_fit_weeks is not None:
+                    msg = "Received unused 'num_fit_weeks' with prop ED strategy 'transition'; ignoring."
+                    logger.warning(msg)
             case _:
                 msg = f"Received invalid/unimplemented strategy {_}"
                 raise ValueError(msg)
         return self
+
+
+class FlusightHospitalizations(BaseModel):
+    """Specifications for generating hospitalizations forecasts."""
+
+    pass
 
 
 class FlusightForecastOutput(BaseModel):
@@ -208,6 +251,10 @@ class FlusightForecastOutput(BaseModel):
 
     reference_date: date = Field(
         description="'YYYY-MM-DD' date to treat as reference date when creating horizons and target dates for submission file."
+    )
+    hospitalizations: FlusightHospitalizations | None = Field(
+        default_factory=FlusightHospitalizations,
+        description="Add 'wk inc flu hosp' quantile forecasts and rate-trend forecasts to submission file. Set to null to disable all hospitalization outputs, omit to enable.",
     )
     rate_trends_source: str | None = Field(
         None,

--- a/epymodelingsuite/schema/output.py
+++ b/epymodelingsuite/schema/output.py
@@ -390,7 +390,6 @@ class QuantilesPlotConfig(BaseModel):
                 show_projection=True,
                 show_surveillance=True,
                 show_fitting_window_line=True,
-                columns=4,
                 spacing=0.3,
             ),
         ],
@@ -415,6 +414,11 @@ class QuantilesPlotConfig(BaseModel):
     projection: QuantilesProjectionConfig | bool = Field(
         default_factory=QuantilesProjectionConfig,
         description="Projection period quantile ribbons (default enabled). Set true to use default options, or set options in subfields.",
+    )
+
+    value_column: str = Field(
+        "hospitalizations",
+        description="Column name for projection quantiles to plot. Common values: 'hospitalizations', 'ed_signal', 'value'. Must match a transition name in output.quantiles.transitions.",
     )
 
     @field_validator("grid")

--- a/epymodelingsuite/schema/output.py
+++ b/epymodelingsuite/schema/output.py
@@ -623,9 +623,9 @@ class OutputConfiguration(BaseModel):
                         f"flusight_format.rate_trends_source='{self.flusight_format.rate_trends_source}' "
                         "but no surveillance sources defined in output.options.surveillance"
                     )
-                if self.flusight_format.prop_ed:
+                if self.flusight_format.prop_ed and self.flusight_format.prop_ed.strategy != "transition":
                     errors.append(
-                        f"flusight_format.prop_ed='{self.flusight_format.prop_ed}' "
+                        f"flusight_format.prop_ed with strategy '{self.flusight_format.prop_ed.strategy}' "
                         "but no surveillance sources defined in output.options.surveillance"
                     )
 
@@ -661,7 +661,10 @@ class OutputConfiguration(BaseModel):
                     f"not found in surveillance sources: {available_sources}"
                 )
             if self.flusight_format.prop_ed:
-                if self.flusight_format.prop_ed.ed_source not in available_sources:
+                if (
+                    self.flusight_format.prop_ed.ed_source
+                    and self.flusight_format.prop_ed.ed_source not in available_sources
+                ):
                     errors.append(
                         f"flusight_format.prop_ed.ed_source='{self.flusight_format.prop_ed.ed_source}' "
                         f"not found in surveillance sources: {available_sources}"

--- a/epymodelingsuite/schema/output.py
+++ b/epymodelingsuite/schema/output.py
@@ -110,6 +110,20 @@ class ObservedValuesConfig(BaseModel):
     value_column: str = Field(description="Name of column containing observed values in observed data CSV")
     date_column: str = Field(description="Name of column containing target dates in observed data CSV")
     location_column: str = Field(description="Name of column containing location in observed data CSV")
+    location_format: str = Field(
+        default="ISO",
+        description="Format of location identifiers in observed data. Options: ISO, FIPS, abbreviation, name, epydemix_population",
+    )
+
+    @field_validator("location_format")
+    @classmethod
+    def validate_location_format(cls, v: str) -> str:
+        """Ensure location_format is a valid option."""
+        valid_formats = {"ISO", "FIPS", "abbreviation", "name", "epydemix_population"}
+        if v not in valid_formats:
+            msg = f"location_format must be one of {valid_formats}, got '{v}'"
+            raise ValueError(msg)
+        return v
 
 
 class RescaleStrategyEnum(str, Enum):

--- a/epymodelingsuite/utils/__init__.py
+++ b/epymodelingsuite/utils/__init__.py
@@ -19,7 +19,7 @@ from .distributions import distribution_to_scipy
 from .expression_eval import RetrieveName, SafeEvalVisitor, safe_eval
 from .formatting import format_data_size, format_duration
 from .location import convert_location_name_format, get_location_codebook, validate_iso3166
-from .populations import get_population_codebook, make_dummy_population
+from .populations import get_population_codebook, get_total_population, make_dummy_population
 
 __all__ = [
     # Common utilities
@@ -43,5 +43,6 @@ __all__ = [
     "validate_iso3166",
     # Population utilities
     "get_population_codebook",
+    "get_total_population",
     "make_dummy_population",
 ]

--- a/epymodelingsuite/utils/populations.py
+++ b/epymodelingsuite/utils/populations.py
@@ -16,6 +16,84 @@ def get_population_codebook() -> pd.DataFrame:
     return population_codebook
 
 
+def get_total_population(epydemix_name: str) -> int:
+    """Get total population for a given epydemix location name.
+
+    Population data is sourced from load_epydemix_population(epydemix_name).total_population.
+
+    Parameters
+    ----------
+    epydemix_name : str
+        Location name in epydemix format (e.g., "United_States_Alabama")
+
+    Returns
+    -------
+    int
+        Total population for the location
+
+    Raises
+    ------
+    KeyError
+        If the location name is not found in the lookup table
+    """
+    POPULATION_LOOKUP = {
+        "United_States": 338120586,
+        "United_States_Alabama": 5108468,
+        "United_States_Alaska": 733406,
+        "United_States_Arizona": 7431344,
+        "United_States_Arkansas": 3067732,
+        "United_States_California": 38965193,
+        "United_States_Colorado": 5877610,
+        "United_States_Connecticut": 3617176,
+        "United_States_Delaware": 1031890,
+        "United_States_District_of_Columbia": 678972,
+        "United_States_Florida": 22610726,
+        "United_States_Georgia": 11029227,
+        "United_States_Hawaii": 1435138,
+        "United_States_Idaho": 1964726,
+        "United_States_Illinois": 12549689,
+        "United_States_Indiana": 6862199,
+        "United_States_Iowa": 3207004,
+        "United_States_Kansas": 2940546,
+        "United_States_Kentucky": 4526154,
+        "United_States_Louisiana": 4573749,
+        "United_States_Maine": 1395722,
+        "United_States_Maryland": 6180253,
+        "United_States_Massachusetts": 7001399,
+        "United_States_Michigan": 10037261,
+        "United_States_Minnesota": 5737915,
+        "United_States_Mississippi": 2939690,
+        "United_States_Missouri": 6196156,
+        "United_States_Montana": 1132812,
+        "United_States_Nebraska": 1978379,
+        "United_States_Nevada": 3194176,
+        "United_States_New_Hampshire": 1402054,
+        "United_States_New_Jersey": 9290841,
+        "United_States_New_Mexico": 2114371,
+        "United_States_New_York": 19571216,
+        "United_States_North_Carolina": 10835491,
+        "United_States_North_Dakota": 783926,
+        "United_States_Ohio": 11785935,
+        "United_States_Oklahoma": 4053824,
+        "United_States_Oregon": 4233358,
+        "United_States_Pennsylvania": 12961683,
+        "United_States_Rhode_Island": 1095962,
+        "United_States_South_Carolina": 5373555,
+        "United_States_South_Dakota": 919318,
+        "United_States_Tennessee": 7126489,
+        "United_States_Texas": 30503301,
+        "United_States_Utah": 3417734,
+        "United_States_Vermont": 647464,
+        "United_States_Virginia": 8715698,
+        "United_States_Washington": 7812880,
+        "United_States_West_Virginia": 1770071,
+        "United_States_Wisconsin": 5910955,
+        "United_States_Wyoming": 584057,
+    }
+
+    return POPULATION_LOOKUP[epydemix_name]
+
+
 def make_dummy_population(model: EpiModel) -> Population:
     """Create a dummy population for testing purposes with 100 individuals per age group."""
     dummy_pop = Population(name="Dummy")

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -517,157 +517,167 @@ def generate_single_quantile_plots(
             continue
         location = calibration.population
 
-        # Filter failed calibration trajectories and projections
-        # calibration.results = filter_failed_calibration_trajectories(calibration.results)
-        calibration.results = filter_failed_projections(calibration.results)
+        try:
+            # Filter failed calibration trajectories and projections
+            # calibration.results = filter_failed_calibration_trajectories(calibration.results)
+            calibration.results = filter_failed_projections(calibration.results)
 
-        cal_quant, proj_quant = _fetch_quantiles_for_location(
-            calibration, plots_config, needs_calibration, needs_projection
-        )
+            cal_quant, proj_quant = _fetch_quantiles_for_location(
+                calibration, plots_config, needs_calibration, needs_projection
+            )
 
-        # Calculate fitting window start and end from calibration quantiles
-        fitting_window_start = None
-        fitting_window_end = None
-        if needs_fitting_window:
-            cal_quant_for_fitting = cal_quant
-            if cal_quant_for_fitting is None:
+            # Calculate fitting window start and end from calibration quantiles
+            fitting_window_start = None
+            fitting_window_end = None
+            if needs_fitting_window:
+                cal_quant_for_fitting = cal_quant
+                if cal_quant_for_fitting is None:
+                    try:
+                        cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
+                            quantiles=[0.5],  # Only need one quantile to get dates
+                            variables=["date", "data"],
+                        )
+                    except (ValueError, AttributeError, TypeError, IndexError) as e:
+                        logger.warning(
+                            "Failed to get calibration quantiles for fitting window for %s: %s",
+                            location,
+                            e,
+                        )
+
+                if cal_quant_for_fitting is not None and "date" in cal_quant_for_fitting.columns:
+                    dates = pd.to_datetime(cal_quant_for_fitting["date"]).dt.date
+                    fitting_window_start = dates.min()
+                    fitting_window_end = dates.max()
+
+            # TODO: Determine which surveillance source to use (logic will be added with per-output processing)
+            # For now, use first available source if any
+            surveillance = None
+            surveillance_config = None
+            if surveillance_data:
+                first_source = next(iter(surveillance_data.values()))
+                surveillance = first_source["data"]
+                surveillance_config = first_source["config"]
+
+            df_surv_full, df_surv_filtered, surveillance_start_date = (
+                _prepare_surveillance_for_location(surveillance, location, proj_quant, cal_quant, surveillance_config)
+                if surveillance_config
+                else (None, None, None)
+            )
+
+            proj_quant_full, proj_quant_filtered = _prepare_projection_quantiles(
+                proj_quant, surveillance_start_date, plots_config
+            )
+
+            # Rename columns to have consistent naming for plotting
+            cal_quant = _rename_value_column(cal_quant, "data")
+            proj_quant_filtered = _rename_value_column(proj_quant_filtered, plots_config.quantiles.value_column)
+            proj_quant_full = _rename_value_column(proj_quant_full, plots_config.quantiles.value_column)
+
+            value_col = "value"
+
+            # Create plots for each configured output
+            for output_config in plots_config.quantiles.outputs:
+                output_name = f"quantiles_{location}_{output_config.type.value}"
+                logger.info("    Creating %s plot for %s", output_config.type.value, location)
+
                 try:
-                    cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
-                        quantiles=[0.5],  # Only need one quantile to get dates
-                        variables=["date", "data"],
-                    )
-                except (ValueError, AttributeError, TypeError) as e:
+                    # Determine which data to use and apply per-output filtering
+                    if output_config.type == QuantilesOutputTypeEnum.FILTERED:
+                        proj_to_use = proj_quant_filtered
+                        surv_to_use = df_surv_filtered
+                    elif output_config.type == QuantilesOutputTypeEnum.FULL:
+                        proj_to_use = proj_quant_full
+                        surv_to_use = df_surv_full
+                    elif output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
+                        # Side-by-side handled separately below
+                        proj_to_use = None
+                        surv_to_use = None
+                    else:
+                        logger.warning("Unknown output type %s for %s", output_config.type, location)
+                        continue
+
+                    # Apply per-output surveillance filtering if needed (for filtered/full types)
+                    if surv_to_use is not None:
+                        # Date-based filtering takes precedence over points-based filtering
+                        if output_config.surveillance_start_date is not None:
+                            start_date = pd.to_datetime(output_config.surveillance_start_date).date()
+                            surv_dates = pd.to_datetime(surv_to_use["date"]).dt.date
+                            surv_to_use = surv_to_use[surv_dates >= start_date]
+                        elif output_config.surveillance_points is not None:
+                            surv_to_use = surv_to_use.sort_values("date").tail(output_config.surveillance_points)
+
+                    # Apply per-output horizon_max if specified (overrides base config)
+                    if proj_to_use is not None and output_config.horizon_max is not None:
+                        proj_dates = pd.to_datetime(proj_to_use["date"]).dt.date
+                        horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
+                        proj_to_use = proj_to_use[proj_dates.values <= horizon_end]
+
+                    # Create the plot
+                    if output_config.type == QuantilesOutputTypeEnum.FILTERED:
+                        fig, ax = _create_filtered_plot(
+                            location,
+                            cal_quant,
+                            proj_to_use,
+                            surv_to_use,
+                            fitting_window_start,
+                            fitting_window_end,
+                            plots_config,
+                            value_col,
+                            output_config,
+                        )
+                    elif output_config.type == QuantilesOutputTypeEnum.FULL:
+                        fig, ax = _create_full_plot(
+                            location,
+                            cal_quant,
+                            proj_to_use,
+                            surv_to_use,
+                            fitting_window_start,
+                            fitting_window_end,
+                            plots_config,
+                            value_col,
+                            output_config,
+                        )
+                    elif output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
+                        fig, (ax_full, ax_filtered) = _create_sidebyside_plot(
+                            location,
+                            cal_quant,
+                            proj_quant_full,
+                            proj_quant_filtered,
+                            df_surv_full,
+                            df_surv_filtered,
+                            fitting_window_start,
+                            fitting_window_end,
+                            plots_config,
+                            value_col,
+                            output_config,
+                        )
+                    else:
+                        logger.warning("Unknown output type %s for %s", output_config.type, location)
+                        continue
+
+                    # Package output
+                    output_objs = []
+                    for figure_output_type in plots_config.figure_output_types:
+                        output_objs.append(
+                            figure_to_output_object(fig, output_name, figure_output_type, plots_config.dpi)
+                        )
+                    out_dict[output_name] = output_objs
+                    plt.close(fig)
+                except Exception as e:
                     logger.warning(
-                        "Failed to get calibration quantiles for fitting window for %s: %s",
+                        "Failed to create %s quantile plot for %s: %s",
+                        output_config.type.value,
                         location,
                         e,
+                        exc_info=True,
                     )
-
-            if cal_quant_for_fitting is not None and "date" in cal_quant_for_fitting.columns:
-                dates = pd.to_datetime(cal_quant_for_fitting["date"]).dt.date
-                fitting_window_start = dates.min()
-                fitting_window_end = dates.max()
-
-        # TODO: Determine which surveillance source to use (logic will be added with per-output processing)
-        # For now, use first available source if any
-        surveillance = None
-        surveillance_config = None
-        if surveillance_data:
-            first_source = next(iter(surveillance_data.values()))
-            surveillance = first_source["data"]
-            surveillance_config = first_source["config"]
-
-        df_surv_full, df_surv_filtered, surveillance_start_date = (
-            _prepare_surveillance_for_location(surveillance, location, proj_quant, cal_quant, surveillance_config)
-            if surveillance_config
-            else (None, None, None)
-        )
-
-        proj_quant_full, proj_quant_filtered = _prepare_projection_quantiles(
-            proj_quant, surveillance_start_date, plots_config
-        )
-
-        # Rename columns to have consistent naming for plotting
-        cal_quant = _rename_value_column(cal_quant, "data")
-        proj_quant_filtered = _rename_value_column(proj_quant_filtered, plots_config.quantiles.value_column)
-        proj_quant_full = _rename_value_column(proj_quant_full, plots_config.quantiles.value_column)
-
-        value_col = "value"
-
-        # Create plots for each configured output
-        for output_config in plots_config.quantiles.outputs:
-            output_name = f"quantiles_{location}_{output_config.type.value}"
-            logger.info("    Creating %s plot for %s", output_config.type.value, location)
-
-            try:
-                # Determine which data to use and apply per-output filtering
-                if output_config.type == QuantilesOutputTypeEnum.FILTERED:
-                    proj_to_use = proj_quant_filtered
-                    surv_to_use = df_surv_filtered
-                elif output_config.type == QuantilesOutputTypeEnum.FULL:
-                    proj_to_use = proj_quant_full
-                    surv_to_use = df_surv_full
-                elif output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
-                    # Side-by-side handled separately below
-                    proj_to_use = None
-                    surv_to_use = None
-                else:
-                    logger.warning("Unknown output type %s for %s", output_config.type, location)
-                    continue
-
-                # Apply per-output surveillance filtering if needed (for filtered/full types)
-                if surv_to_use is not None:
-                    # Date-based filtering takes precedence over points-based filtering
-                    if output_config.surveillance_start_date is not None:
-                        start_date = pd.to_datetime(output_config.surveillance_start_date).date()
-                        surv_dates = pd.to_datetime(surv_to_use["date"]).dt.date
-                        surv_to_use = surv_to_use[surv_dates >= start_date]
-                    elif output_config.surveillance_points is not None:
-                        surv_to_use = surv_to_use.sort_values("date").tail(output_config.surveillance_points)
-
-                # Apply per-output horizon_max if specified (overrides base config)
-                if proj_to_use is not None and output_config.horizon_max is not None:
-                    proj_dates = pd.to_datetime(proj_to_use["date"]).dt.date
-                    horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
-                    proj_to_use = proj_to_use[proj_dates.values <= horizon_end]
-
-                # Create the plot
-                if output_config.type == QuantilesOutputTypeEnum.FILTERED:
-                    fig, ax = _create_filtered_plot(
-                        location,
-                        cal_quant,
-                        proj_to_use,
-                        surv_to_use,
-                        fitting_window_start,
-                        fitting_window_end,
-                        plots_config,
-                        value_col,
-                        output_config,
-                    )
-                elif output_config.type == QuantilesOutputTypeEnum.FULL:
-                    fig, ax = _create_full_plot(
-                        location,
-                        cal_quant,
-                        proj_to_use,
-                        surv_to_use,
-                        fitting_window_start,
-                        fitting_window_end,
-                        plots_config,
-                        value_col,
-                        output_config,
-                    )
-                elif output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
-                    fig, (ax_full, ax_filtered) = _create_sidebyside_plot(
-                        location,
-                        cal_quant,
-                        proj_quant_full,
-                        proj_quant_filtered,
-                        df_surv_full,
-                        df_surv_filtered,
-                        fitting_window_start,
-                        fitting_window_end,
-                        plots_config,
-                        value_col,
-                        output_config,
-                    )
-                else:
-                    logger.warning("Unknown output type %s for %s", output_config.type, location)
-                    continue
-
-                # Package output
-                output_objs = []
-                for figure_output_type in plots_config.figure_output_types:
-                    output_objs.append(figure_to_output_object(fig, output_name, figure_output_type, plots_config.dpi))
-                out_dict[output_name] = output_objs
-                plt.close(fig)
-            except Exception as e:
-                logger.warning(
-                    "Failed to create %s quantile plot for %s: %s",
-                    output_config.type.value,
-                    location,
-                    e,
-                    exc_info=True,
-                )
+        except Exception as e:
+            logger.warning(
+                "Failed to process location %s for quantile plots: %s",
+                location,
+                e,
+                exc_info=True,
+            )
 
 
 def generate_quantile_grid_plot(
@@ -733,39 +743,47 @@ def generate_quantile_grid_plot(
     for calibration in calibrations:
         loc = calibration.population
 
-        # Filter failed calibration trajectories and projections
-        # calibration.results = filter_failed_calibration_trajectories(calibration.results)
-        calibration.results = filter_failed_projections(calibration.results)
+        try:
+            # Filter failed calibration trajectories and projections
+            # calibration.results = filter_failed_calibration_trajectories(calibration.results)
+            calibration.results = filter_failed_projections(calibration.results)
 
-        cal_quant, proj_quant_raw = _fetch_quantiles_for_location(
-            calibration, plots_config, needs_calibration, needs_projection
-        )
-        if cal_quant is not None:
-            location_cal_quants[loc] = cal_quant
-        if proj_quant_raw is not None:
-            location_proj_quants_raw[loc] = proj_quant_raw
+            cal_quant, proj_quant_raw = _fetch_quantiles_for_location(
+                calibration, plots_config, needs_calibration, needs_projection
+            )
+            if cal_quant is not None:
+                location_cal_quants[loc] = cal_quant
+            if proj_quant_raw is not None:
+                location_proj_quants_raw[loc] = proj_quant_raw
 
-        # Calculate fitting window start and end from calibration quantiles
-        if needs_fitting_window:
-            # Fetch calibration quantiles for fitting window calculation even if not displaying them
-            cal_quant_for_fitting = location_cal_quants.get(loc)
-            if cal_quant_for_fitting is None:
-                try:
-                    cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
-                        quantiles=[0.5],  # Only need one quantile to get dates
-                        variables=["date", "data"],
-                    )
-                except (ValueError, AttributeError, TypeError, IndexError) as e:
-                    logger.warning(
-                        "Failed to get calibration quantiles for fitting window for %s: %s",
-                        loc,
-                        e,
-                    )
+            # Calculate fitting window start and end from calibration quantiles
+            if needs_fitting_window:
+                # Fetch calibration quantiles for fitting window calculation even if not displaying them
+                cal_quant_for_fitting = location_cal_quants.get(loc)
+                if cal_quant_for_fitting is None:
+                    try:
+                        cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
+                            quantiles=[0.5],  # Only need one quantile to get dates
+                            variables=["date", "data"],
+                        )
+                    except (ValueError, AttributeError, TypeError, IndexError) as e:
+                        logger.warning(
+                            "Failed to get calibration quantiles for fitting window for %s: %s",
+                            loc,
+                            e,
+                        )
 
-            if cal_quant_for_fitting is not None and "date" in cal_quant_for_fitting.columns:
-                dates = pd.to_datetime(cal_quant_for_fitting["date"]).dt.date
-                location_fitting_window_starts[loc] = dates.min()
-                location_fitting_window_ends[loc] = dates.max()
+                if cal_quant_for_fitting is not None and "date" in cal_quant_for_fitting.columns:
+                    dates = pd.to_datetime(cal_quant_for_fitting["date"]).dt.date
+                    location_fitting_window_starts[loc] = dates.min()
+                    location_fitting_window_ends[loc] = dates.max()
+        except Exception as e:
+            logger.warning(
+                "Failed to process location %s for grid quantile plots: %s",
+                loc,
+                e,
+                exc_info=True,
+            )
 
     # Go over collected data, plot grid, and add to output dict
     if location_cal_quants or location_proj_quants_raw:
@@ -803,27 +821,35 @@ def generate_quantile_grid_plot(
                 logger.debug(f"Surveillance data shape: {surveillance_df.shape}")
 
                 for loc in location_proj_quants_raw:
-                    cal_quant = location_cal_quants.get(loc)
-                    proj_quant_raw = location_proj_quants_raw.get(loc)
+                    try:
+                        cal_quant = location_cal_quants.get(loc)
+                        proj_quant_raw = location_proj_quants_raw.get(loc)
 
-                    logger.debug(f"Preparing surveillance for location: {loc}")
-                    df_surv_full, df_surv_filtered, surveillance_start_date = _prepare_surveillance_for_location(
-                        surveillance_df, loc, proj_quant_raw, cal_quant, surveillance_config
-                    )
-                    logger.debug(
-                        f"Location {loc}: surv_full={df_surv_full.shape if df_surv_full is not None else None}, surv_filtered={df_surv_filtered.shape if df_surv_filtered is not None else None}"
-                    )
+                        logger.debug(f"Preparing surveillance for location: {loc}")
+                        df_surv_full, df_surv_filtered, surveillance_start_date = _prepare_surveillance_for_location(
+                            surveillance_df, loc, proj_quant_raw, cal_quant, surveillance_config
+                        )
+                        logger.debug(
+                            f"Location {loc}: surv_full={df_surv_full.shape if df_surv_full is not None else None}, surv_filtered={df_surv_filtered.shape if df_surv_filtered is not None else None}"
+                        )
 
-                    # Use the appropriate surveillance data based on output type
-                    if output_type_name == "filtered":
-                        if df_surv_filtered is not None:
-                            location_surveillance_for_output[loc] = df_surv_filtered
-                    elif output_type_name == "full":
-                        if df_surv_full is not None:
-                            location_surveillance_for_output[loc] = df_surv_full
+                        # Use the appropriate surveillance data based on output type
+                        if output_type_name == "filtered":
+                            if df_surv_filtered is not None:
+                                location_surveillance_for_output[loc] = df_surv_filtered
+                        elif output_type_name == "full":
+                            if df_surv_full is not None:
+                                location_surveillance_for_output[loc] = df_surv_full
 
-                    if surveillance_start_date is not None:
-                        surveillance_start_dates[loc] = surveillance_start_date
+                        if surveillance_start_date is not None:
+                            surveillance_start_dates[loc] = surveillance_start_date
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to prepare surveillance data for location %s in grid plot: %s",
+                            loc,
+                            e,
+                            exc_info=True,
+                        )
 
             # Prepare projection quantiles for this output (using surveillance start dates if available)
             location_proj_quants_for_output = {}
@@ -943,35 +969,51 @@ def generate_quantile_grid_plot(
                         surveillance_config = source["config"]
 
                         for loc in location_proj_quants_raw:
-                            cal_quant = location_cal_quants.get(loc)
-                            proj_quant_raw = location_proj_quants_raw.get(loc)
+                            try:
+                                cal_quant = location_cal_quants.get(loc)
+                                proj_quant_raw = location_proj_quants_raw.get(loc)
 
-                            df_surv_full, df_surv_filtered, surveillance_start_date = (
-                                _prepare_surveillance_for_location(
-                                    surveillance_df, loc, proj_quant_raw, cal_quant, surveillance_config
+                                df_surv_full, df_surv_filtered, surveillance_start_date = (
+                                    _prepare_surveillance_for_location(
+                                        surveillance_df, loc, proj_quant_raw, cal_quant, surveillance_config
+                                    )
                                 )
-                            )
 
-                            if df_surv_full is not None:
-                                location_surveillance_full_sbs[loc] = df_surv_full
-                            if df_surv_filtered is not None:
-                                location_surveillance_filtered_sbs[loc] = df_surv_filtered
-                            if surveillance_start_date is not None:
-                                surveillance_start_dates_sbs[loc] = surveillance_start_date
+                                if df_surv_full is not None:
+                                    location_surveillance_full_sbs[loc] = df_surv_full
+                                if df_surv_filtered is not None:
+                                    location_surveillance_filtered_sbs[loc] = df_surv_filtered
+                                if surveillance_start_date is not None:
+                                    surveillance_start_dates_sbs[loc] = surveillance_start_date
+                            except Exception as e:
+                                logger.warning(
+                                    "Failed to prepare surveillance data for location %s in side-by-side grid plot: %s",
+                                    loc,
+                                    e,
+                                    exc_info=True,
+                                )
 
                     # Prepare projection quantiles
                     for loc, proj_quant_raw in location_proj_quants_raw.items():
-                        surveillance_start_date = surveillance_start_dates_sbs.get(loc)
-                        proj_quant_full, proj_quant_filtered = _prepare_projection_quantiles(
-                            proj_quant_raw, surveillance_start_date, plots_config
-                        )
-                        if proj_quant_full is not None:
-                            location_proj_quants_full_sbs[loc] = _rename_value_column(
-                                proj_quant_full, plots_config.quantiles.value_column
+                        try:
+                            surveillance_start_date = surveillance_start_dates_sbs.get(loc)
+                            proj_quant_full, proj_quant_filtered = _prepare_projection_quantiles(
+                                proj_quant_raw, surveillance_start_date, plots_config
                             )
-                        if proj_quant_filtered is not None:
-                            location_proj_quants_filtered_sbs[loc] = _rename_value_column(
-                                proj_quant_filtered, plots_config.quantiles.value_column
+                            if proj_quant_full is not None:
+                                location_proj_quants_full_sbs[loc] = _rename_value_column(
+                                    proj_quant_full, plots_config.quantiles.value_column
+                                )
+                            if proj_quant_filtered is not None:
+                                location_proj_quants_filtered_sbs[loc] = _rename_value_column(
+                                    proj_quant_filtered, plots_config.quantiles.value_column
+                                )
+                        except Exception as e:
+                            logger.warning(
+                                "Failed to prepare projection quantiles for location %s in side-by-side grid plot: %s",
+                                loc,
+                                e,
+                                exc_info=True,
                             )
 
                     # Get all locations
@@ -1261,8 +1303,11 @@ def generate_posterior_grid_plot(
         loc = calibration.population
         try:
             posterior_df = calibration.results.get_posterior_distribution()
-            location_posteriors[loc] = posterior_df
-            all_params.update(col for col in posterior_df.columns if col not in ["sim_id", "location"])
+            if not posterior_df.empty:
+                location_posteriors[loc] = posterior_df
+                all_params.update(col for col in posterior_df.columns if col not in ["sim_id", "location"])
+            else:
+                logger.warning("Skipping posterior plot for %s: posterior data is empty", loc)
         except (ValueError, AttributeError) as e:
             logger.warning("Failed to get posterior distribution for %s: %s", loc, e)
 

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -205,18 +205,42 @@ def _prepare_projection_quantiles(
 
 def _rename_value_column(df: pd.DataFrame | None, old_name: str) -> pd.DataFrame | None:
     """
-    Return a copy with `old_name` renamed to `value` if the column exists; otherwise return df unchanged.
+    Return a copy with `old_name` renamed to `value` if the column exists.
 
     Parameters
     ----------
     df : pd.DataFrame or None
-        Dataframe to inspect and rename.
+        DataFrame containing quantile data.
     old_name : str
-        Column name to replace with `value`.
+        Column name to rename to 'value'.
+
+    Returns
+    -------
+    pd.DataFrame or None
+        DataFrame with renamed column, or None if input is None.
+
+    Raises
+    ------
+    ValueError
+        If df is not None and old_name is not found in columns.
     """
-    if df is not None and old_name in df.columns:
+    if df is None:
+        return None
+
+    if old_name in df.columns:
         return df.rename(columns={old_name: "value"})
-    return df
+
+    # Column not found - provide helpful error message
+    metadata_cols = {"date", "location", "quantile"}
+    available_value_cols = [c for c in df.columns if c not in metadata_cols]
+
+    msg = (
+        f"Column '{old_name}' not found in quantiles DataFrame. "
+        f"Available value columns: {available_value_cols}. "
+        f"Check output.plots.quantiles.value_column in your config matches "
+        f"a transition in output.quantiles.transitions."
+    )
+    raise ValueError(msg)
 
 
 def _create_filtered_plot(
@@ -522,10 +546,9 @@ def generate_single_quantile_plots(
         )
 
         # Rename columns to have consistent naming for plotting
-        # TODO: Calibration uses "data", projection uses "hospitalizations" - make this configurable
         cal_quant = _rename_value_column(cal_quant, "data")
-        proj_quant_filtered = _rename_value_column(proj_quant_filtered, "hospitalizations")
-        proj_quant_full = _rename_value_column(proj_quant_full, "hospitalizations")
+        proj_quant_filtered = _rename_value_column(proj_quant_filtered, plots_config.quantiles.value_column)
+        proj_quant_full = _rename_value_column(proj_quant_full, plots_config.quantiles.value_column)
 
         value_col = "value"
 
@@ -786,11 +809,13 @@ def generate_quantile_grid_plot(
                 if output_type_name == "filtered":
                     if proj_quant_filtered is not None:
                         location_proj_quants_for_output[loc] = _rename_value_column(
-                            proj_quant_filtered, "hospitalizations"
+                            proj_quant_filtered, plots_config.quantiles.value_column
                         )
                 elif output_type_name == "full":
                     if proj_quant_full is not None:
-                        location_proj_quants_for_output[loc] = _rename_value_column(proj_quant_full, "hospitalizations")
+                        location_proj_quants_for_output[loc] = _rename_value_column(
+                            proj_quant_full, plots_config.quantiles.value_column
+                        )
 
             # Set data to use for this output
             if output_type_name in ["filtered", "full"]:
@@ -914,11 +939,11 @@ def generate_quantile_grid_plot(
                         )
                         if proj_quant_full is not None:
                             location_proj_quants_full_sbs[loc] = _rename_value_column(
-                                proj_quant_full, "hospitalizations"
+                                proj_quant_full, plots_config.quantiles.value_column
                             )
                         if proj_quant_filtered is not None:
                             location_proj_quants_filtered_sbs[loc] = _rename_value_column(
-                                proj_quant_filtered, "hospitalizations"
+                                proj_quant_filtered, plots_config.quantiles.value_column
                             )
 
                     # Get all locations

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -207,19 +207,33 @@ def _prepare_projection_quantiles(
 
 def _rename_value_column(df: pd.DataFrame | None, old_name: str) -> pd.DataFrame | None:
     """
-    Return a copy with `old_name` renamed to `value` if the column exists.
+    Select the specified value column and rename it to 'value', keeping only metadata columns.
+
+    This function filters the DataFrame to keep only metadata columns (date, quantile, population)
+    plus the specified value column, then renames that column to 'value'.
+
+    NOTE: The rename to 'value' is necessary because plot_calibration_projection() uses a single
+    value_col parameter for both calibration and projection quantiles. Since calibration uses
+    'data' and projection uses configurable columns (e.g., 'ed_signal'), we need a common name.
+
+    The column selection is critical to avoid duplicate column names. CalibrationResults.get_projection_quantiles()
+    returns 269 columns including a pre-existing 'value' column (from epydemix) plus all transitions
+    (ed_signal, hospitalizations, etc.) and compartments. Simply renaming without filtering would
+    create two 'value' columns, causing pivot() to fail with "Data must be 1-dimensional, got ndarray
+    of shape (N, 2)".
 
     Parameters
     ----------
     df : pd.DataFrame or None
-        DataFrame containing quantile data.
+        DataFrame containing quantile data with multiple value columns.
     old_name : str
-        Column name to rename to 'value'.
+        Column name to select and rename to 'value'.
 
     Returns
     -------
     pd.DataFrame or None
-        DataFrame with renamed column, or None if input is None.
+        DataFrame with only metadata columns plus the selected value column renamed to 'value',
+        or None if input is None.
 
     Raises
     ------
@@ -230,11 +244,15 @@ def _rename_value_column(df: pd.DataFrame | None, old_name: str) -> pd.DataFrame
         return None
 
     if old_name in df.columns:
-        return df.rename(columns={old_name: "value"})
+        # Select only metadata columns plus the specified value column
+        # This excludes the pre-existing 'value' column and all other transitions/compartments
+        metadata_cols = ["date", "quantile", "population"]
+        cols_to_keep = [c for c in metadata_cols if c in df.columns] + [old_name]
+        return df[cols_to_keep].rename(columns={old_name: "value"})
 
     # Column not found - provide helpful error message
-    metadata_cols = {"date", "location", "quantile"}
-    available_value_cols = [c for c in df.columns if c not in metadata_cols]
+    metadata_cols_for_error = {"date", "location", "quantile", "population"}
+    available_value_cols = [c for c in df.columns if c not in metadata_cols_for_error]
 
     msg = (
         f"Column '{old_name}' not found in quantiles DataFrame. "

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -121,13 +121,14 @@ def _prepare_surveillance_for_location(
     )
 
     # Full surveillance (no filtering)
+    # Select columns before renaming to avoid duplicates if source data already has 'value' column
     if not surv.empty:
-        df_surv_full = surv.rename(
+        df_surv_full = surv[[surveillance_config.date_column, surveillance_config.value_column]].rename(
             columns={
                 surveillance_config.date_column: "date",
                 surveillance_config.value_column: "value",
             }
-        )[["date", "value"]]
+        )
 
     # Filtered surveillance
     surv_filtered = surv.copy()
@@ -141,12 +142,13 @@ def _prepare_surveillance_for_location(
             ]
 
     if not surv_filtered.empty:
-        df_surv_filtered = surv_filtered.rename(
+        # Select columns before renaming to avoid duplicates if source data already has 'value' column
+        df_surv_filtered = surv_filtered[[surveillance_config.date_column, surveillance_config.value_column]].rename(
             columns={
                 surveillance_config.date_column: "date",
                 surveillance_config.value_column: "value",
             }
-        )[["date", "value"]]
+        )
 
         if not df_surv_filtered.empty:
             surveillance_start_date = pd.to_datetime(df_surv_filtered["date"]).min().date()

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -659,7 +659,13 @@ def generate_single_quantile_plots(
                 out_dict[output_name] = output_objs
                 plt.close(fig)
             except Exception as e:
-                logger.warning("Failed to create %s quantile plot for %s: %s", output_config.type.value, location, e)
+                logger.warning(
+                    "Failed to create %s quantile plot for %s: %s",
+                    output_config.type.value,
+                    location,
+                    e,
+                    exc_info=True,
+                )
 
 
 def generate_quantile_grid_plot(
@@ -915,7 +921,7 @@ def generate_quantile_grid_plot(
                     out_dict[f"quantiles_grid_{output_type_name}"] = output_objs
                     plt.close(fig)
                 except Exception as e:
-                    logger.warning(f"Failed to create {output_type_name} quantile grid plot: %s", e)
+                    logger.warning("Failed to create %s quantile grid plot: %s", output_type_name, e, exc_info=True)
 
             elif output_type_name == "side_by_side":
                 # Side-by-side grid plot
@@ -1105,7 +1111,7 @@ def generate_quantile_grid_plot(
                         out_dict["quantiles_grid_sidebyside"] = output_objs
                         plt.close(fig)
                 except Exception as e:
-                    logger.warning(f"Failed to create sidebyside quantile grid plot: {e}")
+                    logger.warning("Failed to create sidebyside quantile grid plot: %s", e, exc_info=True)
 
 
 def generate_single_location_posterior_plots(
@@ -1186,7 +1192,9 @@ def generate_single_location_posterior_plots(
                     )
                     axes[idx].set_title(param)
                 except Exception as e:
-                    logger.warning("Failed to create posterior histogram for %s - %s: %s", location, param, e)
+                    logger.warning(
+                        "Failed to create posterior histogram for %s - %s: %s", location, param, e, exc_info=True
+                    )
                     axes[idx].set_visible(False)
 
             # Hide unused subplots
@@ -1274,4 +1282,4 @@ def generate_posterior_grid_plot(
             out_dict["posterior_grid"] = output_objs
             plt.close(fig)
         except Exception as e:
-            logger.warning("Failed to create posterior grid plot: %s", e)
+            logger.warning("Failed to create posterior grid plot: %s", e, exc_info=True)

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -116,7 +116,9 @@ def _prepare_surveillance_for_location(
     if surveillance is None:
         return df_surv_full, df_surv_filtered, surveillance_start_date
 
-    surv = get_data_in_location(surveillance, location, surveillance_config.location_column)
+    surv = get_data_in_location(
+        surveillance, location, surveillance_config.location_column, surveillance_config.location_format
+    )
 
     # Full surveillance (no filtering)
     if not surv.empty:

--- a/tests/builders/test_utils.py
+++ b/tests/builders/test_utils.py
@@ -1,0 +1,110 @@
+"""Tests for builders.utils module."""
+
+from datetime import date
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from epymodelingsuite.builders.utils import get_data_in_location, get_data_in_window
+
+
+class TestGetDataInWindow:
+    """Test the get_data_in_window function."""
+
+    @pytest.fixture
+    def sample_data(self):
+        """Create sample data with unsorted dates."""
+        return pd.DataFrame(
+            {
+                "date": ["2024-01-05", "2024-01-01", "2024-01-10", "2024-01-03", "2024-01-08"],
+                "value": [50, 10, 100, 30, 80],
+                "location": ["US", "US", "US", "US", "US"],
+            }
+        )
+
+    @pytest.fixture
+    def calibration_config(self):
+        """Create a mock calibration config."""
+        config = Mock()
+        config.fitting_window.start_date = date(2024, 1, 3)
+        config.fitting_window.end_date = date(2024, 1, 8)
+        config.comparison = [Mock()]
+        config.comparison[0].observed_date_column = "date"
+        return config
+
+    def test_filters_by_date_window(self, sample_data, calibration_config):
+        """Test that data is filtered to the correct date window."""
+        result = get_data_in_window(sample_data, calibration_config)
+
+        # Should include dates from 2024-01-03 to 2024-01-08
+        expected_values = {30, 50, 80}  # Values for dates 03, 05, 08
+        assert set(result["value"].values) == expected_values
+        assert len(result) == 3
+
+    def test_sorts_by_date_ascending_by_default(self, sample_data, calibration_config):
+        """Test that data is sorted by date in ascending order (oldest to newest)."""
+        result = get_data_in_window(sample_data, calibration_config)
+
+        # Should be sorted: 2024-01-03, 2024-01-05, 2024-01-08
+        expected_values = [30, 50, 80]
+        assert list(result["value"].values) == expected_values
+
+        # Verify dates are in ascending order
+        dates = pd.to_datetime(result["date"]).dt.date.tolist()
+        assert dates == sorted(dates)
+
+    def test_sort_false_preserves_original_order(self, sample_data, calibration_config):
+        """Test that sort=False preserves the original order from the filtered data."""
+        result = get_data_in_window(sample_data, calibration_config, sort=False)
+
+        # Should preserve original order: indices 0, 3, 4 from sample_data
+        # Values: 50 (2024-01-05), 30 (2024-01-03), 80 (2024-01-08)
+        expected_values = [50, 30, 80]
+        assert list(result["value"].values) == expected_values
+
+    def test_resets_index_when_sorting(self, sample_data, calibration_config):
+        """Test that index is reset when sorting."""
+        result = get_data_in_window(sample_data, calibration_config, sort=True)
+
+        # Index should be reset to 0, 1, 2
+        assert list(result.index) == [0, 1, 2]
+
+    def test_empty_result_when_no_data_in_window(self, sample_data):
+        """Test that empty DataFrame is returned when no data is in the window."""
+        config = Mock()
+        config.fitting_window.start_date = date(2025, 1, 1)
+        config.fitting_window.end_date = date(2025, 1, 10)
+        config.comparison = [Mock()]
+        config.comparison[0].observed_date_column = "date"
+
+        result = get_data_in_window(sample_data, config)
+        assert len(result) == 0
+
+
+class TestGetDataInLocation:
+    """Test the get_data_in_location function."""
+
+    @pytest.fixture
+    def sample_data(self):
+        """Create sample data with multiple locations."""
+        return pd.DataFrame(
+            {
+                "location": ["US-CA", "US-NY", "US-CA", "US-TX", "US-CA"],
+                "value": [100, 200, 150, 300, 120],
+            }
+        )
+
+    def test_filters_by_location_iso_format(self, sample_data):
+        """Test filtering by location using ISO format."""
+        result = get_data_in_location(sample_data, "US-CA", "location", location_format="ISO")
+
+        assert len(result) == 3
+        assert all(result["location"] == "US-CA")
+        assert list(result["value"].values) == [100, 150, 120]
+
+    def test_empty_result_when_location_not_found(self, sample_data):
+        """Test that empty DataFrame is returned when location is not found."""
+        result = get_data_in_location(sample_data, "US-FL", "location", location_format="ISO")
+
+        assert len(result) == 0

--- a/tests/schema/test_output.py
+++ b/tests/schema/test_output.py
@@ -1,0 +1,126 @@
+"""Tests for output schema validation."""
+
+from datetime import date
+
+import pytest
+
+from epymodelingsuite.schema.output import (
+    FlusightForecastOutput,
+    FlusightPropED,
+    ObservedValuesConfig,
+    OutputConfiguration,
+    OutputOptions,
+    PropEDStrategyEnum,
+)
+
+
+class TestFlusightPropEDValidation:
+    """Test FlusightPropED schema validation."""
+
+    def test_transition_strategy_without_ed_source(self):
+        """Test that transition strategy works without ed_source specified."""
+        # This should not raise validation errors
+        prop_ed = FlusightPropED(
+            strategy=PropEDStrategyEnum.transition,
+            transition_name="ed_prop",
+        )
+        assert prop_ed.strategy == PropEDStrategyEnum.transition
+        assert prop_ed.transition_name == "ed_prop"
+        assert prop_ed.ed_source is None
+
+    def test_transition_strategy_requires_transition_name(self):
+        """Test that transition strategy requires transition_name."""
+        with pytest.raises(ValueError, match="requires field 'transition_name'"):
+            FlusightPropED(strategy=PropEDStrategyEnum.transition)
+
+    def test_calibration_window_requires_ed_source(self):
+        """Test that calibration_window strategy requires ed_source."""
+        with pytest.raises(ValueError, match="requires field 'ed_source'"):
+            FlusightPropED(
+                strategy=PropEDStrategyEnum.calibration_window,
+                num_fit_weeks=4,
+            )
+
+    def test_surveillance_window_requires_ed_source(self):
+        """Test that surveillance_window strategy requires ed_source."""
+        with pytest.raises(ValueError, match="requires field 'ed_source'"):
+            FlusightPropED(
+                strategy=PropEDStrategyEnum.surveillance_window,
+                hosp_source="hosp",
+                fit_start=date(2025, 1, 1),
+                fit_end=date(2025, 2, 1),
+            )
+
+
+class TestOutputConfigurationSurveillanceValidation:
+    """Test OutputConfiguration surveillance reference validation."""
+
+    def test_prop_ed_transition_without_surveillance_options(self):
+        """Test that prop_ed with transition strategy doesn't require surveillance options."""
+        # This should raise an error because prop_ed without transition strategy
+        # requires surveillance sources
+        config = OutputConfiguration(
+            flusight_format=FlusightForecastOutput(
+                reference_date=date(2025, 1, 1),
+                hospitalizations=None,
+                prop_ed=FlusightPropED(
+                    strategy=PropEDStrategyEnum.transition,
+                    transition_name="ed_prop",
+                ),
+            ),
+        )
+        # Should not raise - transition strategy doesn't need surveillance sources
+        # because ed_source is None and not checked when None
+        assert config.flusight_format.prop_ed.strategy == PropEDStrategyEnum.transition
+
+    def test_prop_ed_with_ed_source_validates_surveillance(self):
+        """Test that ed_source is validated against available surveillance sources."""
+        with pytest.raises(ValueError, match="not found in surveillance sources"):
+            OutputConfiguration(
+                options=OutputOptions(
+                    surveillance={
+                        "hosp": ObservedValuesConfig(
+                            data_path="/fake/path.csv",
+                            value_column="value",
+                            date_column="date",
+                            location_column="location",
+                            location_format="ISO",
+                        ),
+                    }
+                ),
+                flusight_format=FlusightForecastOutput(
+                    reference_date=date(2025, 1, 1),
+                    hospitalizations=None,
+                    prop_ed=FlusightPropED(
+                        strategy=PropEDStrategyEnum.calibration_window,
+                        ed_source="nonexistent_source",  # This doesn't exist
+                        num_fit_weeks=4,
+                    ),
+                ),
+            )
+
+    def test_prop_ed_transition_with_valid_surveillance(self):
+        """Test that prop_ed transition strategy works with surveillance defined (even though not needed)."""
+        config = OutputConfiguration(
+            options=OutputOptions(
+                surveillance={
+                    "prop_ed": ObservedValuesConfig(
+                        data_path="/fake/path.csv",
+                        value_column="value",
+                        date_column="date",
+                        location_column="location",
+                        location_format="ISO",
+                    ),
+                }
+            ),
+            flusight_format=FlusightForecastOutput(
+                reference_date=date(2025, 1, 1),
+                hospitalizations=None,
+                prop_ed=FlusightPropED(
+                    strategy=PropEDStrategyEnum.transition,
+                    transition_name="ed_prop",
+                    # ed_source is None (not specified)
+                ),
+            ),
+        )
+        assert config.flusight_format.prop_ed.ed_source is None

--- a/tests/visualization/test_generators.py
+++ b/tests/visualization/test_generators.py
@@ -7,8 +7,8 @@ import pandas as pd
 import pytest
 
 from epymodelingsuite.schema.dispatcher import CalibrationOutput
-from epymodelingsuite.schema.output import PlotsConfig, QuantilesPlotConfig, QuantilesSurveillanceConfig
-from epymodelingsuite.visualization.generators import generate_single_quantile_plots
+from epymodelingsuite.schema.output import ObservedValuesConfig, PlotsConfig, QuantilesPlotConfig
+from epymodelingsuite.visualization.generators import _rename_value_column, generate_single_quantile_plots
 
 
 class TestSurveillanceDataFiltering:
@@ -254,3 +254,32 @@ class TestSurveillanceDataFiltering:
             # Surveillance should be None when no matching location (for both plots)
             assert df_surv_filtered is None
             assert df_surv_full is None
+
+
+class TestRenameValueColumn:
+    """Test _rename_value_column helper function."""
+
+    def test_rename_existing_column(self):
+        """Test renaming when column exists."""
+        df = pd.DataFrame({"date": ["2024-01-01"], "ed_signal": [100], "quantile": [0.5]})
+        result = _rename_value_column(df, "ed_signal")
+        assert "value" in result.columns
+        assert "ed_signal" not in result.columns
+        assert result["value"].iloc[0] == 100
+
+    def test_rename_none_input(self):
+        """Test with None input."""
+        result = _rename_value_column(None, "hospitalizations")
+        assert result is None
+
+    def test_rename_missing_column_raises_error(self):
+        """Test error when column doesn't exist."""
+        df = pd.DataFrame({"date": ["2024-01-01"], "ed_signal": [100], "quantile": [0.5]})
+        with pytest.raises(ValueError, match="Column 'hospitalizations' not found"):
+            _rename_value_column(df, "hospitalizations")
+
+    def test_error_message_suggests_available_columns(self):
+        """Test error message lists available columns."""
+        df = pd.DataFrame({"date": ["2024-01-01"], "ed_signal": [100], "other_transition": [200], "quantile": [0.5]})
+        with pytest.raises(ValueError, match=r"Available value columns:.*ed_signal.*other_transition"):
+            _rename_value_column(df, "hospitalizations")

--- a/tests/visualization/test_generators.py
+++ b/tests/visualization/test_generators.py
@@ -8,7 +8,11 @@ import pytest
 
 from epymodelingsuite.schema.dispatcher import CalibrationOutput
 from epymodelingsuite.schema.output import ObservedValuesConfig, PlotsConfig, QuantilesPlotConfig
-from epymodelingsuite.visualization.generators import _rename_value_column, generate_single_quantile_plots
+from epymodelingsuite.visualization.generators import (
+    _prepare_surveillance_for_location,
+    _rename_value_column,
+    generate_single_quantile_plots,
+)
 
 
 class TestSurveillanceDataFiltering:
@@ -256,6 +260,59 @@ class TestSurveillanceDataFiltering:
             assert df_surv_full is None
 
 
+class TestPrepareSurveillanceForLocation:
+    """Test _prepare_surveillance_for_location helper function."""
+
+    def test_handles_duplicate_value_column(self):
+        """Test that preparing surveillance data avoids duplicate 'value' columns."""
+        # Create surveillance data with both 'value' and 'original_value' columns
+        # This simulates real-world data where both columns exist
+        surveillance_df = pd.DataFrame(
+            {
+                "date": pd.date_range("2024-01-01", periods=5, freq="D"),
+                "location_iso": ["US-AL"] * 5,
+                "value": [100.0, 200.0, 300.0, 400.0, 500.0],  # Existing 'value' column
+                "original_value": [0.01, 0.02, 0.03, 0.04, 0.05],  # Column we want to rename to 'value'
+            }
+        )
+
+        # Configure to use 'original_value' as the value column
+        config = ObservedValuesConfig(
+            data_path="dummy.csv",
+            date_column="date",
+            value_column="original_value",
+            location_column="location_iso",
+            location_format="ISO",
+        )
+
+        # Call the function
+        df_surv_full, df_surv_filtered, _ = _prepare_surveillance_for_location(
+            surveillance=surveillance_df,
+            location="US-AL",
+            proj_quant=None,
+            cal_quant=None,
+            surveillance_config=config,
+        )
+
+        # Verify df_surv_full has exactly 2 columns: date and value
+        assert df_surv_full is not None
+        assert len(df_surv_full.columns) == 2
+        assert list(df_surv_full.columns) == ["date", "value"]
+
+        # Verify df['value'] returns a Series, not a DataFrame
+        assert isinstance(df_surv_full["value"], pd.Series)
+
+        # Verify the values are from 'original_value', not the pre-existing 'value' column
+        assert df_surv_full["value"].iloc[0] == 0.01
+        assert df_surv_full["value"].iloc[4] == 0.05
+
+        # Same checks for filtered surveillance
+        assert df_surv_filtered is not None
+        assert len(df_surv_filtered.columns) == 2
+        assert list(df_surv_filtered.columns) == ["date", "value"]
+        assert isinstance(df_surv_filtered["value"], pd.Series)
+
+
 class TestRenameValueColumn:
     """Test _rename_value_column helper function."""
 
@@ -266,6 +323,33 @@ class TestRenameValueColumn:
         assert "value" in result.columns
         assert "ed_signal" not in result.columns
         assert result["value"].iloc[0] == 100
+
+    def test_handles_duplicate_value_column(self):
+        """Test that renaming avoids duplicate 'value' columns when source has pre-existing 'value'."""
+        # Simulates projection quantiles with 269 columns including both 'value' and 'ed_signal'
+        df = pd.DataFrame(
+            {
+                "date": ["2024-01-01", "2024-01-02"],
+                "quantile": [0.5, 0.5],
+                "population": ["US-AL", "US-AL"],
+                "value": [999.0, 999.0],  # Pre-existing 'value' column from epydemix
+                "ed_signal": [100.0, 200.0],  # Column we want to rename to 'value'
+                "other_column": [1, 2],  # Extra column that should be filtered out
+            }
+        )
+
+        result = _rename_value_column(df, "ed_signal")
+
+        # Should have exactly 4 columns: date, quantile, population, value
+        assert len(result.columns) == 4
+        assert list(result.columns) == ["date", "quantile", "population", "value"]
+
+        # result['value'] should be a Series, not a DataFrame
+        assert isinstance(result["value"], pd.Series)
+
+        # Values should be from 'ed_signal', not the pre-existing 'value' column
+        assert result["value"].iloc[0] == 100.0
+        assert result["value"].iloc[1] == 200.0
 
     def test_rename_none_input(self):
         """Test with None input."""


### PR DESCRIPTION
## Summary
- Support output of prop ED forecasts from calibration with new `strategy: transition` option
- Graceful handling of errors during output generation when projection trajectories fail and get filtered
- Improved robustness of calibration data loading and plotting

## Changes

### New Features

**Flusight format**
- Add `strategy: transition` for prop ED forecasts that directly uses UDF-computed transitions (e.g., `ed_prop`) without rescaling
  - Rename `RescaleStrategyEnum` → `PropEDStrategyEnum` with new `transition` value
  - Add `transition_name` field to `FlusightPropED` (required for transition strategy)
  - Add `FlusightHospitalizations` schema for toggling hospitalization outputs (pass `hospitalizations: null` to disable)
  - Implement transition strategy in `make_prop_ed_flusightforecast()`: collect projection quantiles for specified transition and format to FluSight
  - Make hospitalization quantiles and rate-trends conditional on `hospitalizations` field

**Utilities**
- Add `get_total_population()` in utils/populations.py for efficient population lookup (for use in ED prop calibration UDFs)

**Plots**
- Add `value_column` and `location_format` configurability for quantile plots
- Add `location_format` field to surveillance configuration

### Bug Fixes
**Data preparation**
- Fix duplicate column bug in surveillance data preparation: filter columns before rename in `_rename_value_column()` 
- Sort observed data by date (old to new) in `get_data_in_window()` for consistent ABC distance calculations

**Output generation**
- Fix rescaling_factors merge when using transition strategy (return empty DataFrame instead of None)
- Fix flusight format validation for transition strategy without `ed_source`

### Error Handling
**Graceful failure handling**
- Wrap location and output loops in `try-except` in plot generators to continue processing on individual failures
  - Each file and each panel inside a plot fails gracefully
  - Add detailed tracebacks with `exc_info=True` to plot generation error logging
- Skip model metadata collection for calibrations without projections (dispatcher/builder.py)
- Catch ValueError when extracting projection window dates from failed calibrations (dispatcher/output.py)

### Deprecations
- Add deprecation warning to `make_scenario_projection_simulate_wrappers()` (not used in main pipeline)
