### PR TITLE
Add timespan validation

### DIFF
--- a/epymodelingsuite/schema/basemodel.py
+++ b/epymodelingsuite/schema/basemodel.py
@@ -486,6 +486,48 @@ class BaseEpiModel(BaseModel):
             raise ValueError(msg)
         return self
 
+    @model_validator(mode="after")
+    def check_weekly_frequency_end_date(self: "BaseEpiModel") -> "BaseEpiModel":
+        """Warn if end_date doesn't match the expected day for weekly resample_frequency."""
+        if not self.simulation or not self.simulation.resample_frequency:
+            return self
+
+        freq = self.simulation.resample_frequency
+        # Check if it's a weekly frequency (W-MON, W-TUE, ..., W-SUN)
+        if not freq.startswith("W-"):
+            return self
+
+        # Map day abbreviation to (weekday number, full day name)
+        # weekday(): Monday=0, ..., Sunday=6
+        day_info = {
+            "MON": (0, "Monday"),
+            "TUE": (1, "Tuesday"),
+            "WED": (2, "Wednesday"),
+            "THU": (3, "Thursday"),
+            "FRI": (4, "Friday"),
+            "SAT": (5, "Saturday"),
+            "SUN": (6, "Sunday"),
+        }
+        day_abbrev = freq[2:]  # Extract "SAT" from "W-SAT"
+
+        if day_abbrev not in day_info:
+            return self  # Not a recognized weekly frequency, skip validation
+
+        expected_weekday, expected_day_name = day_info[day_abbrev]
+        actual_weekday = self.timespan.end_date.weekday()
+
+        if actual_weekday != expected_weekday:
+            actual_day = self.timespan.end_date.strftime("%A")
+            logger.warning(
+                "When resample_frequency is '%s', %s is preferred for timespan.end_date. "
+                "Received end_date=%s which is a %s.",
+                freq,
+                expected_day_name,
+                self.timespan.end_date,
+                actual_day,
+            )
+        return self
+
     @field_validator("interventions")
     @classmethod
     def enforce_single_school_closure(cls, v: list[Intervention]) -> list[Intervention]:

--- a/epymodelingsuite/schema/general.py
+++ b/epymodelingsuite/schema/general.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import timedelta
+from datetime import date, timedelta
 
 from ..utils.common import parse_transition_name, strip_agegroup_suffix, to_set
 from .basemodel import BasemodelConfig
@@ -324,6 +324,55 @@ def _compare_prop_ed_window_against_calibration_window(
             raise ValueError(msg)
 
 
+def _ensure_fitting_window_within_timespan(
+    basemodel: "BasemodelConfig",
+    calibration: CalibrationConfiguration | None,
+) -> None:
+    """
+    Validate fitting window is contained within simulation timespan.
+
+    Parameters
+    ----------
+    basemodel : BasemodelConfig
+        Base model configuration.
+    calibration : CalibrationConfiguration or None
+        Calibration configuration, if present.
+
+    Raises
+    ------
+    ValueError
+        Raised when fitting window extends beyond simulation timespan.
+    """
+    if calibration is None:
+        return
+
+    fitting_window = calibration.fitting_window
+    timespan = basemodel.model.timespan
+
+    # Use computed fields that handle both date and epiweek specifications
+    fit_start = fitting_window.epiweek_start_date
+    fit_end = fitting_window.epiweek_end_date
+
+    # Validate fitting_window end <= timespan.end_date
+    if fit_end > timespan.end_date:
+        msg = (
+            f"Fitting window end_date ({fit_end}) exceeds "
+            f"simulation timespan end_date ({timespan.end_date}). "
+            "The fitting window must be contained within the simulation timespan."
+        )
+        raise ValueError(msg)
+
+    # Validate fitting_window start >= timespan.start_date
+    # (only when timespan.start_date is a concrete date)
+    if isinstance(timespan.start_date, date) and fit_start < timespan.start_date:
+        msg = (
+            f"Fitting window start_date ({fit_start}) is before "
+            f"simulation timespan start_date ({timespan.start_date}). "
+            "The fitting window must be contained within the simulation timespan."
+        )
+        raise ValueError(msg)
+
+
 def validate_cross_config_consistency(
     base_config: BasemodelConfig,
     modelset_config: SamplingConfig | CalibrationConfig,
@@ -398,6 +447,10 @@ def validate_cross_config_consistency(
     # - Ensure all transitions used in calibration comparison exist in basemodel
     base_transitions = {f"{t.source}_to_{t.target}_total" for t in basemodel.transitions or []}
     _ensure_transitions_valid(base_transitions, calibration)
+
+    # Fitting window consistency checks
+    # - Ensure fitting window is within simulation timespan
+    _ensure_fitting_window_within_timespan(base_config, calibration)
 
     # Output config consistency checks
     # - Validate output config references if provided

--- a/tests/schema/test_basemodel.py
+++ b/tests/schema/test_basemodel.py
@@ -1,0 +1,159 @@
+"""Tests for basemodel schema validation."""
+
+import logging
+from datetime import date
+
+import pytest
+
+from epymodelingsuite.schema.basemodel import (
+    BaseEpiModel,
+    Compartment,
+    Parameter,
+    Population,
+    Simulation,
+    Timespan,
+    Transition,
+)
+
+
+@pytest.fixture
+def base_model_params():
+    """Create minimal base model parameters for testing."""
+    return {
+        "population": Population(age_groups=["0-17", "18-64", "65+"]),
+        "compartments": [
+            Compartment(id="S", init="default"),
+            Compartment(id="I", init=100),
+            Compartment(id="R"),
+        ],
+        "transitions": [
+            Transition(type="mediated", source="S", target="I", rate="beta", mediator="I"),
+            Transition(type="spontaneous", source="I", target="R", rate=0.1),
+        ],
+        "parameters": {
+            "beta": Parameter(type="scalar", value=0.3),
+        },
+    }
+
+
+class TestWeeklyFrequencyEndDateValidation:
+    """Test validation of weekly resample_frequency against end_date."""
+
+    def test_wsat_with_saturday_end_date_valid(self, base_model_params):
+        """Test that W-SAT with Saturday end_date is valid."""
+        # 2024-01-06 is a Saturday
+        model = BaseEpiModel(
+            timespan=Timespan(start_date=date(2024, 1, 1), end_date=date(2024, 1, 6)),
+            simulation=Simulation(n_sims=10, resample_frequency="W-SAT"),
+            **base_model_params,
+        )
+        assert model.timespan.end_date.weekday() == 5
+
+    def test_wsat_with_non_saturday_end_date_warns(self, base_model_params, caplog):
+        """Test that W-SAT with non-Saturday end_date logs a warning."""
+        caplog.set_level(logging.WARNING)
+        # 2024-01-07 is a Sunday
+        model = BaseEpiModel(
+            timespan=Timespan(start_date=date(2024, 1, 1), end_date=date(2024, 1, 7)),
+            simulation=Simulation(n_sims=10, resample_frequency="W-SAT"),
+            **base_model_params,
+        )
+        assert model is not None
+        assert "Saturday is preferred" in caplog.text
+        assert "Sunday" in caplog.text
+
+    def test_wsat_with_friday_end_date_shows_actual_day(self, base_model_params, caplog):
+        """Test that W-SAT with Friday end_date shows actual day in warning."""
+        caplog.set_level(logging.WARNING)
+        # 2024-01-05 is a Friday
+        model = BaseEpiModel(
+            timespan=Timespan(start_date=date(2024, 1, 1), end_date=date(2024, 1, 5)),
+            simulation=Simulation(n_sims=10, resample_frequency="W-SAT"),
+            **base_model_params,
+        )
+        assert model is not None
+        assert "Friday" in caplog.text
+
+    def test_wsun_with_sunday_end_date_valid(self, base_model_params):
+        """Test that W-SUN with Sunday end_date is valid."""
+        # 2024-01-07 is a Sunday
+        model = BaseEpiModel(
+            timespan=Timespan(start_date=date(2024, 1, 1), end_date=date(2024, 1, 7)),
+            simulation=Simulation(n_sims=10, resample_frequency="W-SUN"),
+            **base_model_params,
+        )
+        assert model.timespan.end_date.weekday() == 6
+
+    def test_wsun_with_non_sunday_end_date_warns(self, base_model_params, caplog):
+        """Test that W-SUN with non-Sunday end_date logs a warning."""
+        caplog.set_level(logging.WARNING)
+        # 2024-01-06 is a Saturday
+        model = BaseEpiModel(
+            timespan=Timespan(start_date=date(2024, 1, 1), end_date=date(2024, 1, 6)),
+            simulation=Simulation(n_sims=10, resample_frequency="W-SUN"),
+            **base_model_params,
+        )
+        assert model is not None
+        assert "Sunday is preferred" in caplog.text
+
+    def test_wmon_with_monday_end_date_valid(self, base_model_params):
+        """Test that W-MON with Monday end_date is valid."""
+        # 2024-01-08 is a Monday
+        model = BaseEpiModel(
+            timespan=Timespan(start_date=date(2024, 1, 1), end_date=date(2024, 1, 8)),
+            simulation=Simulation(n_sims=10, resample_frequency="W-MON"),
+            **base_model_params,
+        )
+        assert model.timespan.end_date.weekday() == 0
+
+    def test_wmon_with_non_monday_end_date_warns(self, base_model_params, caplog):
+        """Test that W-MON with non-Monday end_date logs a warning."""
+        caplog.set_level(logging.WARNING)
+        # 2024-01-07 is a Sunday
+        model = BaseEpiModel(
+            timespan=Timespan(start_date=date(2024, 1, 1), end_date=date(2024, 1, 7)),
+            simulation=Simulation(n_sims=10, resample_frequency="W-MON"),
+            **base_model_params,
+        )
+        assert model is not None
+        assert "Monday is preferred" in caplog.text
+
+    def test_non_weekly_frequency_allows_any_day(self, base_model_params):
+        """Test that non-weekly frequency allows any end_date."""
+        # 2024-01-07 is a Sunday - should be valid with daily frequency
+        model = BaseEpiModel(
+            timespan=Timespan(start_date=date(2024, 1, 1), end_date=date(2024, 1, 7)),
+            simulation=Simulation(n_sims=10, resample_frequency="D"),
+            **base_model_params,
+        )
+        assert model is not None
+
+    def test_no_simulation_allows_any_day(self, base_model_params):
+        """Test that missing simulation field allows any end_date."""
+        # 2024-01-07 is a Sunday - should be valid without simulation
+        model = BaseEpiModel(
+            timespan=Timespan(start_date=date(2024, 1, 1), end_date=date(2024, 1, 7)),
+            simulation=None,
+            **base_model_params,
+        )
+        assert model is not None
+
+    def test_no_resample_frequency_allows_any_day(self, base_model_params):
+        """Test that None resample_frequency allows any end_date."""
+        # 2024-01-07 is a Sunday
+        model = BaseEpiModel(
+            timespan=Timespan(start_date=date(2024, 1, 1), end_date=date(2024, 1, 7)),
+            simulation=Simulation(n_sims=10, resample_frequency=None),
+            **base_model_params,
+        )
+        assert model is not None
+
+    def test_unrecognized_weekly_frequency_skipped(self, base_model_params):
+        """Test that unrecognized W-XXX frequency is skipped (no validation)."""
+        # W-XYZ is not a valid day, so validation is skipped
+        model = BaseEpiModel(
+            timespan=Timespan(start_date=date(2024, 1, 1), end_date=date(2024, 1, 7)),
+            simulation=Simulation(n_sims=10, resample_frequency="W-XYZ"),
+            **base_model_params,
+        )
+        assert model is not None

--- a/tests/test_general_validator.py
+++ b/tests/test_general_validator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 from types import SimpleNamespace
 from typing import Any
 
@@ -8,6 +9,7 @@ import pytest
 
 from epymodelingsuite.schema.general import (
     _ensure_compartments_valid,
+    _ensure_fitting_window_within_timespan,
     _ensure_output_references_valid,
     _ensure_parameters_present,
     _ensure_populations_valid,
@@ -603,3 +605,166 @@ class TestWarnMismatchedObservedDataPaths:
         assert "Observed data paths differ between configs" in caplog.text
         assert "calibration='data/calibration.csv'" in caplog.text
         assert "rate_trends_source ('hosp')='data/output.csv'" in caplog.text
+
+
+class TestEnsureFittingWindowWithinTimespan:
+    """Test validation of fitting window against simulation timespan."""
+
+    def _create_basemodel_with_timespan(
+        self,
+        start_date: date | str,
+        end_date: date,
+    ) -> SimpleNamespace:
+        """Create a mock base config with timespan."""
+        timespan = SimpleNamespace(start_date=start_date, end_date=end_date)
+        model = SimpleNamespace(timespan=timespan)
+        return SimpleNamespace(model=model)
+
+    def _create_calibration_with_fitting_window(
+        self,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        epiweek_start_date: date | None = None,
+        epiweek_end_date: date | None = None,
+    ) -> SimpleNamespace:
+        """Create a mock calibration with fitting window."""
+        # Mimic the computed fields behavior from epiweek_fitting_window
+        fitting_window = SimpleNamespace(
+            start_date=start_date,
+            end_date=end_date,
+            epiweek_start_date=epiweek_start_date if epiweek_start_date else start_date,
+            epiweek_end_date=epiweek_end_date if epiweek_end_date else end_date,
+        )
+        return SimpleNamespace(fitting_window=fitting_window)
+
+    def test_fitting_window_within_timespan_valid(self):
+        """Test that fitting window within timespan is valid."""
+        basemodel = self._create_basemodel_with_timespan(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+        )
+        calibration = self._create_calibration_with_fitting_window(
+            start_date=date(2024, 3, 1),
+            end_date=date(2024, 6, 30),
+        )
+        # Should not raise
+        _ensure_fitting_window_within_timespan(basemodel, calibration)
+
+    def test_fitting_window_end_exceeds_timespan_end_invalid(self):
+        """Test that fitting window end exceeding timespan raises error."""
+        basemodel = self._create_basemodel_with_timespan(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 6, 30),
+        )
+        calibration = self._create_calibration_with_fitting_window(
+            start_date=date(2024, 3, 1),
+            end_date=date(2024, 12, 31),  # Exceeds timespan end
+        )
+        with pytest.raises(ValueError, match="exceeds simulation timespan end_date"):
+            _ensure_fitting_window_within_timespan(basemodel, calibration)
+
+    def test_fitting_window_start_before_timespan_start_invalid(self):
+        """Test that fitting window start before timespan raises error."""
+        basemodel = self._create_basemodel_with_timespan(
+            start_date=date(2024, 3, 1),
+            end_date=date(2024, 12, 31),
+        )
+        calibration = self._create_calibration_with_fitting_window(
+            start_date=date(2024, 1, 1),  # Before timespan start
+            end_date=date(2024, 6, 30),
+        )
+        with pytest.raises(ValueError, match="is before simulation timespan start_date"):
+            _ensure_fitting_window_within_timespan(basemodel, calibration)
+
+    def test_sampled_start_date_skips_start_validation(self):
+        """Test that 'sampled' start_date skips start date validation."""
+        basemodel = self._create_basemodel_with_timespan(
+            start_date="sampled",  # Not a concrete date
+            end_date=date(2024, 12, 31),
+        )
+        calibration = self._create_calibration_with_fitting_window(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 6, 30),
+        )
+        # Should not raise - start date validation skipped
+        _ensure_fitting_window_within_timespan(basemodel, calibration)
+
+    def test_calibrated_start_date_skips_start_validation(self):
+        """Test that 'calibrated' start_date skips start date validation."""
+        basemodel = self._create_basemodel_with_timespan(
+            start_date="calibrated",  # Not a concrete date
+            end_date=date(2024, 12, 31),
+        )
+        calibration = self._create_calibration_with_fitting_window(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 6, 30),
+        )
+        # Should not raise - start date validation skipped
+        _ensure_fitting_window_within_timespan(basemodel, calibration)
+
+    def test_sampled_start_still_validates_end_date(self):
+        """Test that 'sampled' start_date still validates end date."""
+        basemodel = self._create_basemodel_with_timespan(
+            start_date="sampled",
+            end_date=date(2024, 6, 30),
+        )
+        calibration = self._create_calibration_with_fitting_window(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),  # Exceeds timespan end
+        )
+        with pytest.raises(ValueError, match="exceeds simulation timespan end_date"):
+            _ensure_fitting_window_within_timespan(basemodel, calibration)
+
+    def test_no_calibration_skips_validation(self):
+        """Test that None calibration skips validation."""
+        basemodel = self._create_basemodel_with_timespan(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+        )
+        # Should not raise
+        _ensure_fitting_window_within_timespan(basemodel, None)
+
+    def test_exact_boundary_match_valid(self):
+        """Test that fitting window exactly matching timespan is valid."""
+        basemodel = self._create_basemodel_with_timespan(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+        )
+        calibration = self._create_calibration_with_fitting_window(
+            start_date=date(2024, 1, 1),  # Exact match
+            end_date=date(2024, 12, 31),  # Exact match
+        )
+        # Should not raise
+        _ensure_fitting_window_within_timespan(basemodel, calibration)
+
+    def test_epiweek_fitting_window_within_timespan_valid(self):
+        """Test that fitting window via epiweeks within timespan is valid."""
+        basemodel = self._create_basemodel_with_timespan(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 12, 31),
+        )
+        # Simulate epiweek-based fitting window
+        calibration = self._create_calibration_with_fitting_window(
+            start_date=None,  # Not using dates directly
+            end_date=None,
+            epiweek_start_date=date(2024, 3, 3),  # Computed from epiweeks
+            epiweek_end_date=date(2024, 6, 29),
+        )
+        # Should not raise
+        _ensure_fitting_window_within_timespan(basemodel, calibration)
+
+    def test_epiweek_fitting_window_end_exceeds_timespan_invalid(self):
+        """Test that epiweek-based fitting window end exceeding timespan raises error."""
+        basemodel = self._create_basemodel_with_timespan(
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 6, 30),
+        )
+        # Simulate epiweek-based fitting window
+        calibration = self._create_calibration_with_fitting_window(
+            start_date=None,
+            end_date=None,
+            epiweek_start_date=date(2024, 3, 3),
+            epiweek_end_date=date(2024, 12, 28),  # Exceeds timespan end
+        )
+        with pytest.raises(ValueError, match="exceeds simulation timespan end_date"):
+            _ensure_fitting_window_within_timespan(basemodel, calibration)


### PR DESCRIPTION
*To be merged after https://github.com/mobs-lab/epymodelingsuite/pull/197

## Summary
- Warn when end_date doesn't align with weekly resample_frequency (e.g., W-SAT expects Saturday)
- Raise error when fitting window extends beyond simulation timespan

Closes #182