### PR TITLE
Add structured logging support

### DIFF
--- a/epymodelingsuite/__init__.py
+++ b/epymodelingsuite/__init__.py
@@ -1,4 +1,10 @@
 # epymodelingsuite/__init__.py
+# ruff: noqa: E402
+
+from .utils.logging import configure_logging, setup_logger
+
+# Initialize logger with NullHandler (library best practice)
+setup_logger()
 
 from .config_loader import (
     load_basemodel_config_from_file,
@@ -18,6 +24,7 @@ from .vaccinations import (
 __all__ = [
     "add_school_closure_interventions",
     "add_vaccination_schedule",
+    "configure_logging",
     "get_seasonal_transmission_balcan",
     "load_basemodel_config_from_file",
     "load_calibration_config_from_file",
@@ -26,6 +33,5 @@ __all__ = [
     "make_school_closure_dict",
     "make_vaccination_rate_function",
     "scenario_to_epydemix",
-    "setup_epimodel_from_config",
     "smh_data_to_epydemix",
 ]

--- a/epymodelingsuite/dispatcher/builder.py
+++ b/epymodelingsuite/dispatcher/builder.py
@@ -170,7 +170,11 @@ def build_basemodel(*, basemodel_config: BasemodelConfig, **_) -> BuilderOutput:
     -------
         BuilderOutput containing id, seed, EpiModel, and arguments for simulation.
     """
-    logger.info("BUILDER: dispatched for single model.")
+    population = basemodel_config.model.population.name
+    logger.info(
+        f"BUILDER: Building single model for {population}",
+        extra={"stage": "builder", "workflow": "basemodel", "population": population},
+    )
 
     # For compactness
     basemodel = basemodel_config.model
@@ -182,7 +186,9 @@ def build_basemodel(*, basemodel_config: BasemodelConfig, **_) -> BuilderOutput:
     if basemodel.name is not None:
         model.name = basemodel.name
 
-    logger.info("BUILDER: setting up single model...")
+    logger.info(
+        f"BUILDER: Setting up model components for {population}", extra={"stage": "builder", "population": population}
+    )
 
     # This workflow uses a single population
     set_population_from_config(model, basemodel.population.name, basemodel.population.age_groups)
@@ -238,7 +244,10 @@ def build_basemodel(*, basemodel_config: BasemodelConfig, **_) -> BuilderOutput:
         resample_frequency=basemodel.simulation.resample_frequency,
     )
 
-    logger.info("BUILDER: completed for single model.")
+    logger.info(
+        f"BUILDER: Completed building single model for {population}",
+        extra={"stage": "builder", "population": population},
+    )
 
     return BuilderOutput(
         primary_id=0,
@@ -267,7 +276,7 @@ def build_sampling(
     """
     from ..sample_generator import generate_samples
 
-    logger.info("BUILDER: dispatched for sampling.")
+    logger.info("BUILDER: Building sampling workflow", extra={"stage": "builder", "workflow": "sampling"})
 
     # Validate references between basemodel and sampling
     validate_cross_config_consistency(basemodel_config, sampling_config)
@@ -308,7 +317,11 @@ def build_sampling(
     # using the earliest start_date before further duplicating the models.
     models = setup_interventions(models, basemodel, intervention_types, sampled_start_timespan)
 
-    logger.info("BUILDER: using sampled values to modify EpiModels")
+    n_models = len(models) * len(sampled_vars)
+    logger.info(
+        f"BUILDER: Applying sampled values to {n_models} models",
+        extra={"stage": "builder", "workflow": "sampling", "n_models": n_models},
+    )
 
     # Create models with sampled/calculated parameters, apply vaccination and interventions
     simulation_args = []
@@ -371,7 +384,10 @@ def build_sampling(
         f"Mismatch: created {len(final_models)} EpiModels and {len(simulation_args)} simulation specifications."
     )
 
-    logger.info("BUILDER: completed for sampling.")
+    logger.info(
+        f"BUILDER: Completed building {len(final_models)} sampling models",
+        extra={"stage": "builder", "workflow": "sampling", "n_models": len(final_models)},
+    )
     return [
         BuilderOutput(
             primary_id=i, seed=basemodel.random_seed, delta_t=basemodel.timespan.delta_t, model=t[0], simulation=t[1]
@@ -398,7 +414,7 @@ def build_calibration(
     """
     from ..utils import distribution_to_scipy
 
-    logger.info("BUILDER: dispatched for calibration.")
+    logger.info("BUILDER: Building calibration workflow", extra={"stage": "builder", "workflow": "calibration"})
 
     # Validate references between basemodel and calibration
     validate_cross_config_consistency(basemodel_config, calibration_config)
@@ -444,7 +460,11 @@ def build_calibration(
         else calibration.distance_function.user_function
     )
 
-    logger.info("BUILDER: setting up ABCSamplers...")
+    n_populations = len(models)
+    logger.info(
+        f"BUILDER: Setting up {n_populations} ABCSamplers",
+        extra={"stage": "builder", "workflow": "calibration", "n_populations": n_populations},
+    )
 
     # Load observed data from CSV
     observed_raw = pd.read_csv(calibration.observed_data_path)
@@ -514,7 +534,10 @@ def build_calibration(
         f"Mismatch: created {len(models)} EpiModels and {len(calibrators)} ABCSamplers."
     )
 
-    logger.info("BUILDER: completed calibration.")
+    logger.info(
+        f"BUILDER: Completed building {len(calibrators)} calibration models",
+        extra={"stage": "builder", "workflow": "calibration", "n_calibrators": len(calibrators)},
+    )
     return [
         BuilderOutput(
             primary_id=i,

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -851,7 +851,7 @@ def generate_simulation_outputs(
     -------
         A dictionary where keys are intended filenames for writing data, and values are gzip-compressed CSV strings.
     """
-    logger.info("OUTPUT GENERATOR: dispatched for simulation")
+    logger.info("OUTPUT: Generating simulation outputs", extra={"stage": "output", "workflow": "simulation"})
     output = output_config.output
     warnings = set()
 
@@ -865,7 +865,7 @@ def generate_simulation_outputs(
 
     ### Quantiles
     if output.quantiles:
-        logger.info("Generating quantile outputs")
+        logger.info("OUTPUT: Generating quantile outputs", extra={"stage": "output", "workflow": "simulation"})
         for simulation in simulations:
             # Compartments
             if output.quantiles.compartments:
@@ -910,7 +910,7 @@ def generate_simulation_outputs(
 
     ### Trajectories
     if output.trajectories:
-        logger.info("Generating trajectory outputs")
+        logger.info("OUTPUT: Generating trajectory outputs", extra={"stage": "output", "workflow": "simulation"})
         for simulation in simulations:
             for i, traj in enumerate(simulation.results.trajectories):
                 # Compartments
@@ -966,7 +966,7 @@ def generate_simulation_outputs(
 
     ### Model Metadata
     if output.model_meta:
-        logger.info("Generating model metadata outputs")
+        logger.info("OUTPUT: Generating model metadata outputs", extra={"stage": "output", "workflow": "simulation"})
         if output.model_meta.projection_parameters:
             warnings.add("OUTPUT_GENERATOR: Requested projection parameter metadata in simulation workflow, ignoring.")
 
@@ -996,7 +996,7 @@ def generate_simulation_outputs(
     for warning in warnings:
         logger.warning(warning)
 
-    logger.info("Formatting tabular outputs")
+    logger.info("OUTPUT: Formatting tabular outputs", extra={"stage": "output", "workflow": "simulation"})
     out_dict = {}
     if not quantiles_compartments.empty:
         qc_name = "quantiles_compartments"
@@ -1032,8 +1032,10 @@ def generate_simulation_outputs(
         mm_objects = [format_tabular_object(model_meta, mm_name, _type) for _type in output.tabular_output_types]
         out_dict[mm_name] = mm_objects
 
-    logger.info("Output generation complete. Generated %d output types", len(out_dict))
-    logger.info("OUTPUT GENERATOR: completed for simulation")
+    logger.info(
+        f"OUTPUT: Completed generating simulation outputs ({len(out_dict)} output types)",
+        extra={"stage": "output", "workflow": "simulation", "n_outputs": len(out_dict)},
+    )
 
     return out_dict
 
@@ -1054,7 +1056,11 @@ def generate_calibration_outputs(
     -------
         A dictionary where keys are intended filenames for writing data, and values are gzip-compressed CSV strings.
     """
-    logger.info("OUTPUT GENERATOR: dispatched for calibration")
+    n_calibrations = len(calibrations)
+    logger.info(
+        f"OUTPUT: Generating calibration outputs for {n_calibrations} calibrations",
+        extra={"stage": "output", "workflow": "calibration", "n_calibrations": n_calibrations},
+    )
     output = output_config.output
     warnings = set()
 
@@ -1074,7 +1080,7 @@ def generate_calibration_outputs(
 
     ### Quantiles
     if output.quantiles:
-        logger.info("Generating quantile outputs")
+        logger.info("OUTPUT: Generating quantile outputs", extra={"stage": "output", "workflow": "calibration"})
         for calibration in calibrations:  # Calibration quantiles (only for calibration comparison target)
             # Calibration quantiles
             if output.quantiles.calibration:
@@ -1191,7 +1197,7 @@ def generate_calibration_outputs(
 
     ### Trajectories
     if output.trajectories:
-        logger.info("Generating trajectory outputs")
+        logger.info("OUTPUT: Generating trajectory outputs", extra={"stage": "output", "workflow": "calibration"})
         for calibration in calibrations:
             # Collect all trajectories
             try:
@@ -1277,7 +1283,7 @@ def generate_calibration_outputs(
 
     ### Posteriors
     if output.posteriors:
-        logger.info("Generating posterior outputs")
+        logger.info("OUTPUT: Generating posterior outputs", extra={"stage": "output", "workflow": "calibration"})
         for calibration in calibrations:
             # Output last generation (default)
             if output.posteriors == True:
@@ -1307,13 +1313,17 @@ def generate_calibration_outputs(
     ### Hub Formats
 
     # FluSight Forecast Hub
-    logger.info(f"DEBUG: output.flusight_format = {output.flusight_format}")
     if output.flusight_format:
-        logger.info("Generating FluSight forecast hub outputs")
+        logger.info(
+            "OUTPUT: Generating FluSight forecast hub outputs", extra={"stage": "output", "workflow": "calibration"}
+        )
 
         # Quantile forecasts (hospitalizations)
         if output.flusight_format.hospitalizations:
-            logger.info("  - Generating FluSight quantile forecasts (hospitalizations)")
+            logger.info(
+                "OUTPUT: Generating FluSight quantile forecasts (hospitalizations)",
+                extra={"stage": "output", "workflow": "calibration"},
+            )
             for calibration in calibrations:
                 try:
                     # FRAGILE: the name 'hospitalizations' is user-supplied in the modelset as the column to look for in the surveillance data.
@@ -1395,7 +1405,9 @@ def generate_calibration_outputs(
 
         # Rate-trend forecasts (only if hospitalizations is enabled)
         if output.flusight_format.rate_trends_source and output.flusight_format.hospitalizations:
-            logger.info("  - Generating FluSight rate-trend forecasts")
+            logger.info(
+                "OUTPUT: Generating FluSight rate-trend forecasts", extra={"stage": "output", "workflow": "calibration"}
+            )
             # Get surveillance source configuration
             if not output.options or not output.options.surveillance:
                 msg = "rate_trends_source specified but no surveillance sources defined in output.options.surveillance"
@@ -1461,7 +1473,7 @@ def generate_calibration_outputs(
 
     ### Model Metadata
     if output.model_meta:
-        logger.info("Generating model metadata outputs")
+        logger.info("OUTPUT: Generating model metadata outputs", extra={"stage": "output", "workflow": "calibration"})
         for calibration in calibrations:
             # Skip calibrations without projections (failed calibrations)
             if not calibration.results.projections:
@@ -1526,7 +1538,7 @@ def generate_calibration_outputs(
     for warning in warnings:
         logger.warning(warning)
 
-    logger.info("Formatting tabular outputs")
+    logger.info("OUTPUT: Formatting tabular outputs", extra={"stage": "output", "workflow": "calibration"})
     out_dict = {}
     if not quantiles_projection_compartments.empty:
         qc_name = "quantiles_projection_compartments"
@@ -1578,7 +1590,7 @@ def generate_calibration_outputs(
 
     ### Visualization plots
     if output.plots:
-        logger.info("Generating visualization plots")
+        logger.info("OUTPUT: Generating visualization plots", extra={"stage": "output", "workflow": "calibration"})
         plots_config = output.plots
 
         # Extract start_date_reference from first calibration (they should all have the same reference date)
@@ -1588,7 +1600,7 @@ def generate_calibration_outputs(
                 start_date_reference = str(calibration.start_date_reference)
                 break
 
-        logger.info("  - Generating quantile plots")
+        logger.info("OUTPUT: Generating quantile plots", extra={"stage": "output", "workflow": "calibration"})
         # Extract surveillance sources from output config if available
         surveillance_sources = None
         if output.options and output.options.surveillance:
@@ -1596,16 +1608,19 @@ def generate_calibration_outputs(
 
         generate_single_quantile_plots(calibrations, plots_config, out_dict, surveillance_sources)
         generate_quantile_grid_plot(calibrations, plots_config, out_dict, surveillance_sources)
-        logger.info("  - Generating posterior plots")
+        logger.info("OUTPUT: Generating posterior plots", extra={"stage": "output", "workflow": "calibration"})
         generate_single_location_posterior_plots(calibrations, plots_config, out_dict, start_date_reference)
         generate_posterior_grid_plot(calibrations, plots_config, out_dict, start_date_reference)
 
         # Generate categorical plots (requires FluSight rate-trend data)
         if plots_config.categorical:
-            logger.info("  - Generating categorical plots")
+            logger.info("OUTPUT: Generating categorical plots", extra={"stage": "output", "workflow": "calibration"})
             generate_categorical_plots(plots_config, out_dict, hub_format_output)
 
-    logger.info("Output generation complete. Generated %d output types", len(out_dict))
+    logger.info(
+        f"OUTPUT: Completed generating calibration outputs ({len(out_dict)} output types)",
+        extra={"stage": "output", "workflow": "calibration", "n_outputs": len(out_dict)},
+    )
     return out_dict
 
 

--- a/epymodelingsuite/dispatcher/runner.py
+++ b/epymodelingsuite/dispatcher/runner.py
@@ -36,7 +36,8 @@ def run_simulation(configs: BuilderOutput, rng: np.random.Generator | None = Non
     RuntimeError
         If simulation fails.
     """
-    logger.info("RUNNER: running simulation.")
+    population = configs.model.population.name
+    logger.info(f"RUNNER: Running simulation for {population}", extra={"stage": "runner", "population": population})
     start_time = time.time()
 
     # Create RNG if not provided
@@ -46,7 +47,10 @@ def run_simulation(configs: BuilderOutput, rng: np.random.Generator | None = Non
     try:
         results = configs.model.run_simulations(**dict(configs.simulation), rng=rng)
         duration = time.time() - start_time
-        logger.info("RUNNER: completed simulation.")
+        logger.info(
+            f"RUNNER: Completed simulation for {population} in {duration:.2f}s",
+            extra={"stage": "runner", "population": population, "duration_s": duration},
+        )
 
         output = SimulationOutput(
             primary_id=configs.primary_id,
@@ -101,13 +105,17 @@ def run_calibration(configs: BuilderOutput, rng: np.random.Generator | None = No
     RuntimeError
         If calibration fails.
     """
-    logger.info("RUNNER: running calibration.")
+    population = configs.model.population.name
+    logger.info(f"RUNNER: Running calibration for {population}", extra={"stage": "runner", "population": population})
     start_time = time.time()
 
     try:
         results = configs.calibrator.calibrate(strategy=configs.calibration.name, **configs.calibration.options)
         duration = time.time() - start_time
-        logger.info("RUNNER: completed calibration.")
+        logger.info(
+            f"RUNNER: Completed calibration for {population} in {duration:.2f}s",
+            extra={"stage": "runner", "population": population, "duration_s": duration},
+        )
 
         output = CalibrationOutput(
             primary_id=configs.primary_id,
@@ -166,8 +174,11 @@ def run_calibration_with_projection(
     RuntimeError
         If calibration or projection fails.
     """
-    logger.info("RUNNER: running calibration and projection.")
     population = configs.calibrator.parameters["epimodel"].population.name
+    logger.info(
+        f"RUNNER: Running calibration and projection for {population}",
+        extra={"stage": "runner", "population": population},
+    )
 
     # Calibration phase
     calibration_start = time.time()
@@ -176,7 +187,10 @@ def run_calibration_with_projection(
             strategy=configs.calibration.name, **configs.calibration.options
         )
         calibration_duration = time.time() - calibration_start
-        logger.info("RUNNER: completed calibration.")
+        logger.info(
+            f"RUNNER: Completed calibration phase for {population} in {calibration_duration:.2f}s",
+            extra={"stage": "runner", "population": population, "duration_s": calibration_duration},
+        )
     except Exception as e:
         # Create output with None results for error tracking
         output = CalibrationOutput(
@@ -208,7 +222,15 @@ def run_calibration_with_projection(
             iterations=configs.projection.n_trajectories,
         )
         projection_duration = time.time() - projection_start
-        logger.info("RUNNER: completed calibration and projection.")
+        logger.info(
+            f"RUNNER: Completed calibration and projection for {population} (calibration: {calibration_duration:.2f}s, projection: {projection_duration:.2f}s)",
+            extra={
+                "stage": "runner",
+                "population": population,
+                "calibration_s": calibration_duration,
+                "projection_s": projection_duration,
+            },
+        )
 
         output = CalibrationOutput(
             primary_id=configs.primary_id,
@@ -236,7 +258,8 @@ def run_calibration_with_projection(
     except Exception as e:
         projection_duration = time.time() - projection_start
         logger.warning(
-            f"RUNNER: projection failed for model with primary_id={configs.primary_id}, returning calibration results.\nError message: {e}"
+            f"RUNNER: Projection failed for {population} (primary_id={configs.primary_id}), returning calibration results. Error: {e}",
+            extra={"stage": "runner", "population": population, "primary_id": configs.primary_id, "error": str(e)},
         )
 
         output = CalibrationOutput(
@@ -300,15 +323,15 @@ def dispatch_runner(configs: BuilderOutput) -> SimulationOutput | CalibrationOut
 
         # Handle simulation
         if configs.simulation:
-            logger.info("RUNNER: dispatched for simulation.")
+            logger.info("RUNNER: Dispatched for simulation", extra={"stage": "runner"})
             result = run_simulation(configs, rng=rng)
         # Handle calibration
         elif configs.calibration and not configs.projection:
-            logger.info("RUNNER: dispatched for calibration.")
+            logger.info("RUNNER: Dispatched for calibration", extra={"stage": "runner"})
             result = run_calibration(configs, rng=rng)
         # Handle calibration and projection
         elif configs.calibration and configs.projection:
-            logger.info("RUNNER: dispatched for calibration and projection.")
+            logger.info("RUNNER: Dispatched for calibration with projection", extra={"stage": "runner"})
             result = run_calibration_with_projection(configs, rng=rng)
         # Error
         else:

--- a/epymodelingsuite/utils/__init__.py
+++ b/epymodelingsuite/utils/__init__.py
@@ -1,6 +1,7 @@
 """Utility functions for epymodelingsuite.
 
 This package contains utility functions organized by category:
+- logging: Dual-mode logging (local/cloud) configuration
 - expression_eval: Safe expression evaluation for model parameters
 - location: Location validation and conversion utilities
 - populations: Population-related utilities
@@ -20,32 +21,27 @@ from .distributions import distribution_to_scipy
 from .expression_eval import RetrieveName, SafeEvalVisitor, safe_eval
 from .formatting import format_data_size, format_duration
 from .location import convert_location_name_format, get_location_codebook, validate_iso3166
+from .logging import StructuredFormatter, configure_logging, setup_logger
 from .populations import get_population_codebook, get_total_population, make_dummy_population
 
 __all__ = [
-    # Common utilities
-    "parse_timedelta",
-    # Config utilities
-    "identify_config_type",
-    # Data utilities
-    "fetch_hhs_hospitalizations",
-    # Distance utilities
-    "wrmse",
-    # Distribution utilities
-    "distribution_to_scipy",
-    # Expression evaluation
     "RetrieveName",
     "SafeEvalVisitor",
-    "safe_eval",
-    # Formatting utilities
+    "StructuredFormatter",
+    "configure_logging",
+    "convert_location_name_format",
+    "distribution_to_scipy",
+    "fetch_hhs_hospitalizations",
     "format_data_size",
     "format_duration",
-    # Location utilities
-    "convert_location_name_format",
     "get_location_codebook",
-    "validate_iso3166",
-    # Population utilities
     "get_population_codebook",
     "get_total_population",
+    "identify_config_type",
     "make_dummy_population",
+    "parse_timedelta",
+    "safe_eval",
+    "setup_logger",
+    "validate_iso3166",
+    "wrmse",
 ]

--- a/epymodelingsuite/utils/logging.py
+++ b/epymodelingsuite/utils/logging.py
@@ -1,0 +1,211 @@
+"""
+Logging configuration utilities.
+
+This module provides dual-mode logging infrastructure:
+- Local mode: Human-readable console logs for development
+- Cloud mode: JSON structured logs for Google Cloud Logging
+
+Following Python library best practices:
+- Uses NullHandler by default (libraries should not force logging configuration)
+- Provides convenience function for users to enable logging
+- Supports structured logging via the 'extra' parameter
+"""
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+
+def setup_logger() -> None:
+    """
+    Initialize the epymodelingsuite logger with a NullHandler.
+
+    This follows Python logging best practices for libraries:
+    libraries should add a NullHandler to prevent "No handlers found" warnings
+    while allowing users to configure logging as they wish.
+
+    This function is called automatically when epymodelingsuite is imported.
+    """
+    logger = logging.getLogger("epymodelingsuite")
+    logger.addHandler(logging.NullHandler())
+
+
+def configure_logging(
+    mode: str | None = None,
+    level: int | str | None = None,
+    format_string: str | None = None,
+) -> None:
+    """
+    Configure logging for epymodelingsuite.
+
+    Parameters
+    ----------
+    mode : str | None, optional
+        Logging mode: "local" for human-readable output, "cloud" for JSON structured
+        logs (Google Cloud Logging compatible). If None, falls back to EXECUTION_MODE
+        environment variable, then defaults to "local".
+    level : int | str | None, optional
+        Logging level. Can be int (e.g., logging.INFO) or string (e.g., "INFO").
+        If None, uses LOG_LEVEL environment variable (default: INFO).
+    format_string : str | None, optional
+        Custom format string for local mode. If None, uses default format.
+        Ignored in cloud mode.
+
+    Examples
+    --------
+    >>> # Local development (human-readable logs)
+    >>> from epymodelingsuite import configure_logging
+    >>> configure_logging()
+
+    >>> # Cloud deployment (JSON structured logs)
+    >>> configure_logging(mode="cloud")
+
+    >>> # Debug logging
+    >>> configure_logging(level="DEBUG")
+
+    >>> # Using environment variable (for deployment configs)
+    >>> # Set EXECUTION_MODE=cloud in environment, then:
+    >>> configure_logging()  # Will use cloud mode
+    """
+    logger = logging.getLogger("epymodelingsuite")
+
+    # Resolve log level
+    if level is None:
+        level_str = os.getenv("LOG_LEVEL", "INFO").upper()
+        resolved_level: int = getattr(logging, level_str, logging.INFO)
+    elif isinstance(level, str):
+        resolved_level = getattr(logging, level.upper(), logging.INFO)
+    else:
+        resolved_level = level
+
+    # Remove existing handlers to avoid duplicates
+    logger.handlers = []
+
+    # Resolve mode: explicit parameter > env var > default
+    if mode is None:
+        mode = os.getenv("EXECUTION_MODE", "local")
+    mode = mode.lower()
+
+    # Create handler (stdout for Cloud Logging compatibility)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(resolved_level)
+
+    # Set formatter based on mode
+    if mode == "cloud":
+        formatter = StructuredFormatter()
+    else:
+        if format_string is None:
+            format_string = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        formatter = logging.Formatter(format_string, datefmt="%Y-%m-%d %H:%M:%S")
+
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(resolved_level)
+
+
+class StructuredFormatter(logging.Formatter):
+    """
+    JSON formatter for structured logging compatible with Google Cloud Logging.
+
+    This formatter converts log records to JSON format for machine-readable logs,
+    making them easy to parse by log aggregation tools. All fields passed via
+    the 'extra' parameter become JSON fields that can be queried and filtered.
+
+    Output Format
+    -------------
+    {
+        "timestamp": "2024-01-08T10:30:45.123456+00:00",
+        "severity": "INFO",
+        "logger": "epymodelingsuite.dispatcher.runner",
+        "message": "Starting simulation",
+        "population": "US-MA",
+        "stage": "runner"
+    }
+
+    Notes
+    -----
+    - Uses ISO 8601 timestamps
+    - Uses 'severity' field for GCP compatibility (instead of 'level')
+    - All extra fields from logger.info(..., extra={}) are included
+
+    Examples
+    --------
+    >>> import logging
+    >>> from epymodelingsuite.utils.logging import StructuredFormatter
+    >>> logger = logging.getLogger("epymodelingsuite.test")
+    >>> handler = logging.StreamHandler()
+    >>> handler.setFormatter(StructuredFormatter())
+    >>> logger.addHandler(handler)
+    >>> logger.setLevel(logging.INFO)
+    >>> logger.info("Processing population", extra={"population": "US-MA", "n_models": 10})
+    """
+
+    # Standard LogRecord fields that should not be included in extra
+    RESERVED_FIELDS = frozenset(
+        {
+            "name",
+            "msg",
+            "args",
+            "created",
+            "filename",
+            "funcName",
+            "levelname",
+            "levelno",
+            "lineno",
+            "module",
+            "msecs",
+            "message",
+            "pathname",
+            "process",
+            "processName",
+            "relativeCreated",
+            "thread",
+            "threadName",
+            "exc_info",
+            "exc_text",
+            "stack_info",
+            "taskName",
+        }
+    )
+
+    def format(self, record: logging.LogRecord) -> str:
+        """
+        Format a log record as a JSON string.
+
+        Parameters
+        ----------
+        record : logging.LogRecord
+            The log record to format.
+
+        Returns
+        -------
+        str
+            JSON-formatted log message.
+        """
+        # Build the base log entry
+        log_data = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "severity": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Add location information for non-INFO levels (useful for debugging)
+        if record.levelno != logging.INFO:
+            log_data["location"] = f"{record.filename}:{record.lineno}"
+
+        # Add exception info if present
+        if record.exc_info:
+            log_data["exception"] = self.formatException(record.exc_info)
+
+        # Add any extra fields passed via the 'extra' parameter
+        extra_fields = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key not in self.RESERVED_FIELDS and not key.startswith("_")
+        }
+        log_data.update(extra_fields)
+
+        return json.dumps(log_data)


### PR DESCRIPTION
## Summary

Adds dual-mode structured logging: JSON format for Google Cloud deployments (enables log filtering/aggregation), human-readable text for local development. The human readable logs will continue to be printed as before.

Closes #108

## Changes

- Add `epymodelingsuite/utils/logging.py` with `configure_logging()` and `StructuredFormatter`
- Environment-based mode selection: `EXECUTION_MODE=cloud` for JSON, default for text
- Standardize dispatcher log messages with consistent prefixes (`BUILDER:`, `RUNNER:`, `OUTPUT:`) and structured `extra` fields (`stage`, `workflow`, `population`, `duration_s`, etc.)
- Add `python-json-logger` dependency

**Usage:**
```python
from epymodelingsuite import configure_logging
configure_logging()  # Uses EXECUTION_MODE and LOG_LEVEL env vars
```
