### PR TITLE
Validation Error Fix

### DIFF
--- a/epymodelingsuite/schema/calibration.py
+++ b/epymodelingsuite/schema/calibration.py
@@ -129,7 +129,7 @@ class FittingWindow(BaseModel):
         # Specifying with dates
         if self.start_date or self.end_date:
             # Ensure both fields are present
-            if not (bool(self.start_date) and bool(self.end_date)):
+            if self.start_date is None or self.end_date is None:
                 raise ValueError("Must supply both start and end date if specifying fitting window by dates.")
             # Ensure end_date is after start_date
             if self.end_date <= self.start_date:
@@ -142,7 +142,7 @@ class FittingWindow(BaseModel):
 
         # Specifying with epiweeks
         # Ensure all fields are present
-        if not (bool(self.start_epiweek) and bool(self.end_epiweek)):
+        if self.start_epiweek is None or self.end_epiweek is None:
             raise ValueError("Must supply both start and end epiweek if specifying fitting window by epiweeks.")
         # Ensure dates are consistent
         if self.end_epiweek < self.start_epiweek:

--- a/epymodelingsuite/schema/calibration.py
+++ b/epymodelingsuite/schema/calibration.py
@@ -129,7 +129,7 @@ class FittingWindow(BaseModel):
         # Specifying with dates
         if self.start_date or self.end_date:
             # Ensure both fields are present
-            if not (self.start_date and self.end_date):
+            if not (bool(self.start_date) and bool(self.end_date)):
                 raise ValueError("Must supply both start and end date if specifying fitting window by dates.")
             # Ensure end_date is after start_date
             if self.end_date <= self.start_date:
@@ -142,7 +142,7 @@ class FittingWindow(BaseModel):
 
         # Specifying with epiweeks
         # Ensure all fields are present
-        if not (self.start_epiweek and self.end_epiweek):
+        if not (bool(self.start_epiweek) and bool(self.end_epiweek)):
             raise ValueError("Must supply both start and end epiweek if specifying fitting window by epiweeks.")
         # Ensure dates are consistent
         if self.end_epiweek < self.start_epiweek:
@@ -334,7 +334,7 @@ class CalibrationConfiguration(BaseModel):
 
         prior = self.start_date.prior
         reference_date = self.start_date.reference_date
-        fitting_window_end = self.fitting_window.end_date
+        fitting_window_end = self.fitting_window.epiweek_end_date
 
         # Determine max offset based on distribution type
         max_offset = None


### PR DESCRIPTION
When specifying fitting window with epiweeks, an error `Configuration validation error: '>' not supported between instances of 'datetime.date' and 'NoneType'` was caused in `epymodelingsuite.schema.calibration.CalibrationConfiguration.validate_sampled_start_date_against_fitting_window` because this validator was accessing the `start_date` of the fitting window for comparison against the maximum sampled simulation start date.

Changes:
Updated the validator to instead access the computed field `epiweek_start_date` of the fitting window, which will work for both epiweek and date cases.

Verified locally that validation passes.