### PR TITLE
Add calibration data validation with early return

### DIFF
--- a/epymodelingsuite/dispatcher/builder.py
+++ b/epymodelingsuite/dispatcher/builder.py
@@ -45,6 +45,12 @@ from ..vaccinations import reaggregate_vaccines
 logger = logging.getLogger(__name__)
 
 
+class CalibrationDataError(ValueError):
+    """Raised when calibration data validation fails."""
+
+    pass
+
+
 # ===== Helper Functions =====
 
 
@@ -382,19 +388,36 @@ def build_sampling(
 
 @register_builder({"basemodel_config", "calibration_config"})
 def build_calibration(
-    *, basemodel_config: BasemodelConfig, calibration_config: CalibrationConfig, **_
+    *,
+    basemodel_config: BasemodelConfig,
+    calibration_config: CalibrationConfig,
+    skip_invalid_locations: bool = True,
+    **_,
 ) -> list[BuilderOutput]:
     """
     Construct a set of ABCSamplers and arguments for calibration/projection using a BasemodelConfig and CalibrationConfig parsed from YAML.
 
     Parameters
     ----------
-        basemodel: configuration parsed from YAML
-        calibration: configuration parsed from YAML
+    basemodel_config : BasemodelConfig
+        Configuration parsed from YAML.
+    calibration_config : CalibrationConfig
+        Configuration parsed from YAML.
+    skip_invalid_locations : bool, optional
+        If True (default), skip locations with no data in the fitting window
+        and continue with valid locations. If False, raise CalibrationDataError
+        when any location has no data.
 
     Returns
     -------
+    list[BuilderOutput]
         BuilderOutput containing id, seed, ABCSampler, and arguments for calibration and projection.
+
+    Raises
+    ------
+    CalibrationDataError
+        If all locations have no data, or if skip_invalid_locations is False
+        and any location has no data.
     """
     from ..utils import distribution_to_scipy
 
@@ -450,6 +473,33 @@ def build_calibration(
     observed_raw = pd.read_csv(calibration.observed_data_path)
     # Filter to fitting window and sort by date (oldest to newest) for consistent ABC distance calculations
     observed_in_window = get_data_in_window(observed_raw, calibration)
+
+    # Validate data availability for each location
+    from ..schema.data_validation import validate_calibration_data
+
+    valid_locations, invalid_locations = validate_calibration_data(
+        calibration_config=calibration_config,
+        population_names=population_names,
+        observed_data=observed_in_window,
+    )
+
+    # All locations have no data - fail early
+    if not valid_locations:
+        raise CalibrationDataError(f"No valid data for any location. Invalid: {invalid_locations}")
+
+    # Some locations have no data - skip or fail based on parameter
+    if invalid_locations:
+        if skip_invalid_locations:
+            logger.warning(
+                "Skipping %d location(s) with no data: %s",
+                len(invalid_locations),
+                invalid_locations,
+            )
+            # Filter models to only valid locations
+            models = [m for m in models if m.population.name in valid_locations]
+        else:
+            raise CalibrationDataError(f"Data validation failed for locations: {invalid_locations}")
+
     calibrators = []
     location_column = calibration.comparison[0].observed_location_column
     location_format = calibration.comparison[0].observed_location_format

--- a/epymodelingsuite/schema/__init__.py
+++ b/epymodelingsuite/schema/__init__.py
@@ -1,1 +1,11 @@
 # epymodelingsuite/schema/__init__.py
+
+from .data_validation import (
+    validate_calibration_data,
+    validate_calibration_data_for_config_set,
+)
+
+__all__ = [
+    "validate_calibration_data",
+    "validate_calibration_data_for_config_set",
+]

--- a/epymodelingsuite/schema/data_validation.py
+++ b/epymodelingsuite/schema/data_validation.py
@@ -1,0 +1,184 @@
+"""Data validation functions for calibration pipeline.
+
+This module provides functions to validate that observed data exists for
+calibration before running computationally expensive calibration jobs.
+"""
+
+import logging
+
+import pandas as pd
+
+from ..builders.utils import get_data_in_location
+from .calibration import CalibrationConfig
+
+logger = logging.getLogger(__name__)
+
+
+def validate_calibration_data(
+    calibration_config: CalibrationConfig,
+    population_names: list[str],
+    observed_data: pd.DataFrame,
+) -> tuple[list[str], list[str]]:
+    """
+    Validate data availability for each location in fitting window.
+
+    This is the core validation logic that operates on in-memory objects.
+    Use this when configs and data are already loaded (e.g., inside
+    build_calibration). For file-path-based validation, use
+    validate_calibration_data_for_config_set instead.
+
+    This function checks whether observed data exists for each location
+    within the fitting window. It logs detailed errors for invalid locations
+    (useful for CI debugging) and returns lists of valid and invalid locations.
+
+    Parameters
+    ----------
+    calibration_config : CalibrationConfig
+        Calibration configuration containing fitting window and data file info.
+    population_names : list[str]
+        List of population/location names to validate.
+    observed_data : pd.DataFrame
+        Observed data already filtered to the fitting window.
+
+    Returns
+    -------
+    tuple[list[str], list[str]]
+        (valid_locations, invalid_locations) - lists of location names.
+    """
+    calibration = calibration_config.modelset.calibration
+    fitting_window = calibration.fitting_window
+
+    # Get fitting window dates for logging
+    if fitting_window.start_date:
+        window_start = fitting_window.start_date
+        window_end = fitting_window.end_date
+    else:
+        window_start = fitting_window.epiweek_start_date
+        window_end = fitting_window.epiweek_end_date
+
+    # Get column info from comparison spec
+    comparison = calibration.comparison[0]
+    location_column = comparison.observed_location_column
+    location_format = comparison.observed_location_format
+    date_column = comparison.observed_date_column
+
+    valid = []
+    invalid = []
+
+    for location in population_names:
+        location_data = get_data_in_location(observed_data, location, location_column, location_format)
+
+        if location_data.empty:
+            logger.error(
+                "DATA VALIDATION FAILED: No data for location '%s' in fitting window [%s, %s]. Data file: %s",
+                location,
+                window_start,
+                window_end,
+                calibration.observed_data_path,
+            )
+            invalid.append(location)
+        else:
+            logger.debug(
+                "Data validation passed for '%s': %d data points",
+                location,
+                len(location_data),
+            )
+            valid.append(location)
+
+            # Warn if data doesn't cover the full fitting window
+            data_start = pd.to_datetime(location_data[date_column]).min()
+            data_end = pd.to_datetime(location_data[date_column]).max()
+            if data_start > pd.to_datetime(window_start) or data_end < pd.to_datetime(window_end):
+                logger.warning(
+                    "Incomplete data coverage for '%s': data spans [%s, %s] but fitting window is [%s, %s]",
+                    location,
+                    data_start.date(),
+                    data_end.date(),
+                    window_start,
+                    window_end,
+                )
+
+    return valid, invalid
+
+
+def validate_calibration_data_for_config_set(
+    basemodel_path: str,
+    calibration_path: str,
+) -> tuple[bool, str | None]:
+    """
+    Validate calibration data availability from config file paths.
+
+    Convenience wrapper that loads configs and data from files, then
+    calls validate_calibration_data internally. Designed for external
+    scripts (like validate_configs.py) that only have file paths.
+
+    Parameters
+    ----------
+    basemodel_path : str
+        Path to the basemodel YAML configuration file.
+    calibration_path : str
+        Path to the calibration YAML configuration file.
+
+    Returns
+    -------
+    tuple[bool, str | None]
+        (success, error_message) where success indicates if validation
+        passed and error_message contains the error if validation failed.
+    """
+    try:
+        from ..config_loader import (
+            load_basemodel_config_from_file,
+            load_calibration_config_from_file,
+        )
+        from ..builders.utils import get_data_in_window
+        from ..utils import get_location_codebook
+
+        # Load configs
+        basemodel_config = load_basemodel_config_from_file(basemodel_path)
+        calibration_config = load_calibration_config_from_file(calibration_path)
+
+        calibration = calibration_config.modelset.calibration
+
+        # Resolve population names (same logic as create_model_collection)
+        population_names = calibration_config.modelset.population_names
+        if "all" in population_names:
+            # Expand to all locations from codebook
+            population_names = get_location_codebook()["location_name_epydemix"].tolist()
+        elif not population_names:
+            # Use population from basemodel
+            population_names = [basemodel_config.model.population.name]
+
+        # Load and filter observed data
+        observed_raw = pd.read_csv(calibration.observed_data_path)
+        observed_in_window = get_data_in_window(observed_raw, calibration)
+
+        # Check if any data in window at all
+        if observed_in_window.empty:
+            fitting_window = calibration.fitting_window
+            if fitting_window.start_date:
+                window_start = fitting_window.start_date
+                window_end = fitting_window.end_date
+            else:
+                window_start = fitting_window.epiweek_start_date
+                window_end = fitting_window.epiweek_end_date
+            return False, f"No data found in fitting window [{window_start}, {window_end}]"
+
+        # Validate each location
+        valid_locations, invalid_locations = validate_calibration_data(
+            calibration_config=calibration_config,
+            population_names=population_names,
+            observed_data=observed_in_window,
+        )
+
+        if not valid_locations:
+            return False, f"No valid data for any location. Invalid: {invalid_locations}"
+
+        if invalid_locations:
+            return False, f"Data validation failed for locations: {invalid_locations}"
+
+        return True, None
+
+    except FileNotFoundError as e:
+        return False, f"File not found: {e}"
+    except Exception as e:
+        return False, str(e)

--- a/tests/schema/test_data_validation.py
+++ b/tests/schema/test_data_validation.py
@@ -1,0 +1,407 @@
+"""Tests for data validation module."""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from epymodelingsuite.schema.data_validation import (
+    validate_calibration_data,
+    validate_calibration_data_for_config_set,
+)
+
+
+class TestValidateCalibrationData:
+    """Tests for validate_calibration_data function."""
+
+    @pytest.fixture
+    def mock_calibration_config(self):
+        """Create a mock calibration config."""
+        config = MagicMock()
+        config.modelset.calibration.fitting_window.start_date = date(2024, 1, 1)
+        config.modelset.calibration.fitting_window.end_date = date(2024, 3, 1)
+        config.modelset.calibration.fitting_window.epiweek_start_date = None
+        config.modelset.calibration.fitting_window.epiweek_end_date = None
+        config.modelset.calibration.comparison = [MagicMock()]
+        config.modelset.calibration.comparison[0].observed_location_column = "location"
+        config.modelset.calibration.comparison[0].observed_location_format = "ISO"
+        config.modelset.calibration.comparison[0].observed_date_column = "date"
+        config.modelset.calibration.observed_data_path = "/path/to/data.csv"
+        return config
+
+    def test_all_locations_valid(self, mock_calibration_config):
+        """Test when all locations have data."""
+        observed_data = pd.DataFrame(
+            {
+                "location": ["US-CA", "US-CA", "US-NY", "US-NY"],
+                "value": [100, 110, 200, 210],
+                "date": ["2024-01-01", "2024-01-08", "2024-01-01", "2024-01-08"],
+            }
+        )
+
+        with patch("epymodelingsuite.schema.data_validation.get_data_in_location") as mock_get_data:
+            # Return non-empty data for both locations
+            mock_get_data.side_effect = [
+                observed_data[observed_data["location"] == "US-CA"],
+                observed_data[observed_data["location"] == "US-NY"],
+            ]
+
+            valid, invalid = validate_calibration_data(
+                calibration_config=mock_calibration_config,
+                population_names=["US-CA", "US-NY"],
+                observed_data=observed_data,
+            )
+
+        assert valid == ["US-CA", "US-NY"]
+        assert invalid == []
+
+    def test_some_locations_invalid(self, mock_calibration_config):
+        """Test when some locations have no data."""
+        observed_data = pd.DataFrame(
+            {
+                "location": ["US-CA", "US-CA"],
+                "value": [100, 110],
+                "date": ["2024-01-01", "2024-01-08"],
+            }
+        )
+
+        with patch("epymodelingsuite.schema.data_validation.get_data_in_location") as mock_get_data:
+            # Return data for US-CA, empty for US-NY
+            mock_get_data.side_effect = [
+                observed_data,  # US-CA has data
+                pd.DataFrame(),  # US-NY has no data
+            ]
+
+            valid, invalid = validate_calibration_data(
+                calibration_config=mock_calibration_config,
+                population_names=["US-CA", "US-NY"],
+                observed_data=observed_data,
+            )
+
+        assert valid == ["US-CA"]
+        assert invalid == ["US-NY"]
+
+    def test_all_locations_invalid(self, mock_calibration_config):
+        """Test when all locations have no data."""
+        observed_data = pd.DataFrame()
+
+        with patch("epymodelingsuite.schema.data_validation.get_data_in_location") as mock_get_data:
+            # Return empty for all locations
+            mock_get_data.return_value = pd.DataFrame()
+
+            valid, invalid = validate_calibration_data(
+                calibration_config=mock_calibration_config,
+                population_names=["US-CA", "US-NY"],
+                observed_data=observed_data,
+            )
+
+        assert valid == []
+        assert invalid == ["US-CA", "US-NY"]
+
+    def test_logs_error_for_invalid_location(self, mock_calibration_config, caplog):
+        """Test that errors are logged for invalid locations."""
+        import logging
+
+        with patch("epymodelingsuite.schema.data_validation.get_data_in_location") as mock_get_data:
+            mock_get_data.return_value = pd.DataFrame()
+
+            with caplog.at_level(logging.ERROR):
+                validate_calibration_data(
+                    calibration_config=mock_calibration_config,
+                    population_names=["US-CA"],
+                    observed_data=pd.DataFrame(),
+                )
+
+        assert "DATA VALIDATION FAILED" in caplog.text
+        assert "US-CA" in caplog.text
+
+    def test_logs_debug_for_valid_location(self, mock_calibration_config, caplog):
+        """Test that debug logs are created for valid locations."""
+        import logging
+
+        observed_data = pd.DataFrame(
+            {
+                "location": ["US-CA", "US-CA"],
+                "value": [100, 110],
+                "date": ["2024-01-01", "2024-03-01"],
+            }
+        )
+
+        with patch("epymodelingsuite.schema.data_validation.get_data_in_location") as mock_get_data:
+            mock_get_data.return_value = observed_data
+
+            with caplog.at_level(logging.DEBUG):
+                validate_calibration_data(
+                    calibration_config=mock_calibration_config,
+                    population_names=["US-CA"],
+                    observed_data=observed_data,
+                )
+
+        assert "Data validation passed" in caplog.text
+        assert "US-CA" in caplog.text
+
+    def test_logs_warning_for_incomplete_coverage(self, mock_calibration_config, caplog):
+        """Test that warning is logged when data doesn't cover full fitting window."""
+        import logging
+
+        # Data only covers part of the fitting window (Jan 15 - Feb 15, not Jan 1 - Mar 1)
+        observed_data = pd.DataFrame(
+            {
+                "location": ["US-CA", "US-CA"],
+                "value": [100, 110],
+                "date": ["2024-01-15", "2024-02-15"],
+            }
+        )
+
+        with patch("epymodelingsuite.schema.data_validation.get_data_in_location") as mock_get_data:
+            mock_get_data.return_value = observed_data
+
+            with caplog.at_level(logging.WARNING):
+                valid, invalid = validate_calibration_data(
+                    calibration_config=mock_calibration_config,
+                    population_names=["US-CA"],
+                    observed_data=observed_data,
+                )
+
+        # Location should still be valid (has data)
+        assert valid == ["US-CA"]
+        assert invalid == []
+        # But warning should be logged about incomplete coverage
+        assert "Incomplete data coverage" in caplog.text
+        assert "US-CA" in caplog.text
+
+    def test_no_warning_for_full_coverage(self, mock_calibration_config, caplog):
+        """Test that no warning is logged when data covers full fitting window."""
+        import logging
+
+        # Data covers the full fitting window (Jan 1 - Mar 1)
+        observed_data = pd.DataFrame(
+            {
+                "location": ["US-CA", "US-CA"],
+                "value": [100, 110],
+                "date": ["2024-01-01", "2024-03-01"],
+            }
+        )
+
+        with patch("epymodelingsuite.schema.data_validation.get_data_in_location") as mock_get_data:
+            mock_get_data.return_value = observed_data
+
+            with caplog.at_level(logging.WARNING):
+                valid, invalid = validate_calibration_data(
+                    calibration_config=mock_calibration_config,
+                    population_names=["US-CA"],
+                    observed_data=observed_data,
+                )
+
+        assert valid == ["US-CA"]
+        assert invalid == []
+        assert "Incomplete data coverage" not in caplog.text
+
+    def test_uses_epiweek_dates_when_start_date_is_none(self):
+        """Test that epiweek dates are used when start_date is None."""
+        config = MagicMock()
+        config.modelset.calibration.fitting_window.start_date = None
+        config.modelset.calibration.fitting_window.end_date = None
+        config.modelset.calibration.fitting_window.epiweek_start_date = date(2024, 1, 7)
+        config.modelset.calibration.fitting_window.epiweek_end_date = date(2024, 3, 2)
+        config.modelset.calibration.comparison = [MagicMock()]
+        config.modelset.calibration.comparison[0].observed_location_column = "location"
+        config.modelset.calibration.comparison[0].observed_location_format = "ISO"
+        config.modelset.calibration.comparison[0].observed_date_column = "date"
+        config.modelset.calibration.observed_data_path = "/path/to/data.csv"
+
+        with patch("epymodelingsuite.schema.data_validation.get_data_in_location") as mock_get_data:
+            mock_get_data.return_value = pd.DataFrame()
+
+            _, invalid = validate_calibration_data(
+                calibration_config=config,
+                population_names=["US-CA"],
+                observed_data=pd.DataFrame(),
+            )
+
+        assert invalid == ["US-CA"]
+
+
+class TestValidateCalibrationDataForConfigSet:
+    """Tests for validate_calibration_data_for_config_set function."""
+
+    def test_returns_tuple(self):
+        """Test that function returns a tuple of (bool, str|None)."""
+        # Non-existent file should return error
+        success, error = validate_calibration_data_for_config_set(
+            "/nonexistent/basemodel.yml",
+            "/nonexistent/calibration.yml",
+        )
+
+        assert isinstance(success, bool)
+        assert success is False
+        assert error is not None
+        assert isinstance(error, str)
+
+    def test_file_not_found_error(self):
+        """Test that FileNotFoundError is handled gracefully."""
+        success, error = validate_calibration_data_for_config_set(
+            "/nonexistent/basemodel.yml",
+            "/nonexistent/calibration.yml",
+        )
+
+        assert success is False
+        assert error is not None
+        assert "not found" in error.lower() or "no such file" in error.lower()
+
+    @patch("epymodelingsuite.config_loader.load_basemodel_config_from_file")
+    @patch("epymodelingsuite.config_loader.load_calibration_config_from_file")
+    @patch("epymodelingsuite.builders.utils.get_data_in_window")
+    @patch("pandas.read_csv")
+    def test_returns_true_when_all_valid(
+        self,
+        mock_read_csv,
+        mock_get_window,
+        mock_load_calib,
+        mock_load_base,
+    ):
+        """Test that function returns True when all locations are valid."""
+        # Setup mocks
+        mock_load_base.return_value = MagicMock()
+        mock_load_base.return_value.model.population.name = "US-CA"
+
+        mock_load_calib.return_value = MagicMock()
+        mock_load_calib.return_value.modelset.population_names = ["US-CA"]
+        mock_load_calib.return_value.modelset.calibration.observed_data_path = "data.csv"
+        mock_load_calib.return_value.modelset.calibration.fitting_window.start_date = date(2024, 1, 1)
+        mock_load_calib.return_value.modelset.calibration.fitting_window.end_date = date(2024, 3, 1)
+        mock_load_calib.return_value.modelset.calibration.comparison = [MagicMock()]
+        mock_load_calib.return_value.modelset.calibration.comparison[0].observed_location_column = "location"
+        mock_load_calib.return_value.modelset.calibration.comparison[0].observed_location_format = "ISO"
+        mock_load_calib.return_value.modelset.calibration.comparison[0].observed_date_column = "date"
+
+        mock_read_csv.return_value = pd.DataFrame({"col": [1, 2, 3], "location": ["US-CA", "US-CA", "US-CA"]})
+        mock_get_window.return_value = pd.DataFrame({"col": [1, 2], "location": ["US-CA", "US-CA"]})
+
+        with patch("epymodelingsuite.schema.data_validation.get_data_in_location") as mock_get_location:
+            mock_get_location.return_value = pd.DataFrame({"col": [1, 2], "date": ["2024-01-01", "2024-03-01"]})
+
+            success, error = validate_calibration_data_for_config_set(
+                "basemodel.yml",
+                "calibration.yml",
+            )
+
+        assert success is True
+        assert error is None
+
+    @patch("epymodelingsuite.config_loader.load_basemodel_config_from_file")
+    @patch("epymodelingsuite.config_loader.load_calibration_config_from_file")
+    @patch("epymodelingsuite.builders.utils.get_data_in_window")
+    @patch("pandas.read_csv")
+    def test_returns_false_when_invalid_locations(
+        self,
+        mock_read_csv,
+        mock_get_window,
+        mock_load_calib,
+        mock_load_base,
+    ):
+        """Test that function returns False when some locations are invalid."""
+        mock_load_base.return_value = MagicMock()
+        mock_load_calib.return_value = MagicMock()
+        mock_load_calib.return_value.modelset.population_names = ["US-CA", "US-NY"]
+        mock_load_calib.return_value.modelset.calibration.observed_data_path = "data.csv"
+        mock_load_calib.return_value.modelset.calibration.fitting_window.start_date = date(2024, 1, 1)
+        mock_load_calib.return_value.modelset.calibration.fitting_window.end_date = date(2024, 3, 1)
+        mock_load_calib.return_value.modelset.calibration.comparison = [MagicMock()]
+        mock_load_calib.return_value.modelset.calibration.comparison[0].observed_location_column = "location"
+        mock_load_calib.return_value.modelset.calibration.comparison[0].observed_location_format = "ISO"
+        mock_load_calib.return_value.modelset.calibration.comparison[0].observed_date_column = "date"
+
+        mock_read_csv.return_value = pd.DataFrame({"col": [1], "location": ["US-CA"]})
+        mock_get_window.return_value = pd.DataFrame({"col": [1], "location": ["US-CA"]})
+
+        with patch("epymodelingsuite.schema.data_validation.get_data_in_location") as mock_get_location:
+            # US-CA has data, US-NY has no data
+            mock_get_location.side_effect = [
+                pd.DataFrame({"col": [1], "date": ["2024-01-01"]}),  # US-CA
+                pd.DataFrame(),  # US-NY - empty
+            ]
+
+            success, error = validate_calibration_data_for_config_set(
+                "basemodel.yml",
+                "calibration.yml",
+            )
+
+        assert success is False
+        assert error is not None
+        assert "US-NY" in error
+
+    @patch("epymodelingsuite.config_loader.load_basemodel_config_from_file")
+    @patch("epymodelingsuite.config_loader.load_calibration_config_from_file")
+    @patch("epymodelingsuite.builders.utils.get_data_in_window")
+    @patch("pandas.read_csv")
+    def test_returns_false_when_empty_window(
+        self,
+        mock_read_csv,
+        mock_get_window,
+        mock_load_calib,
+        mock_load_base,
+    ):
+        """Test that function returns False when no data in fitting window."""
+        mock_load_base.return_value = MagicMock()
+        mock_load_calib.return_value = MagicMock()
+        mock_load_calib.return_value.modelset.population_names = ["US-CA"]
+        mock_load_calib.return_value.modelset.calibration.observed_data_path = "data.csv"
+        mock_load_calib.return_value.modelset.calibration.fitting_window.start_date = date(2024, 1, 1)
+        mock_load_calib.return_value.modelset.calibration.fitting_window.end_date = date(2024, 3, 1)
+
+        mock_read_csv.return_value = pd.DataFrame({"col": [1]})
+        mock_get_window.return_value = pd.DataFrame()  # Empty window
+
+        success, error = validate_calibration_data_for_config_set(
+            "basemodel.yml",
+            "calibration.yml",
+        )
+
+        assert success is False
+        assert error is not None
+        assert "fitting window" in error.lower()
+
+    @patch("epymodelingsuite.config_loader.load_basemodel_config_from_file")
+    @patch("epymodelingsuite.config_loader.load_calibration_config_from_file")
+    @patch("epymodelingsuite.utils.get_location_codebook")
+    @patch("epymodelingsuite.builders.utils.get_data_in_window")
+    @patch("pandas.read_csv")
+    def test_handles_all_population(
+        self,
+        mock_read_csv,
+        mock_get_window,
+        mock_codebook,
+        mock_load_calib,
+        mock_load_base,
+    ):
+        """Test that 'all' population is expanded from codebook."""
+        mock_load_base.return_value = MagicMock()
+        mock_load_calib.return_value = MagicMock()
+        mock_load_calib.return_value.modelset.population_names = ["all"]
+        mock_load_calib.return_value.modelset.calibration.observed_data_path = "data.csv"
+        mock_load_calib.return_value.modelset.calibration.fitting_window.start_date = date(2024, 1, 1)
+        mock_load_calib.return_value.modelset.calibration.fitting_window.end_date = date(2024, 3, 1)
+        mock_load_calib.return_value.modelset.calibration.comparison = [MagicMock()]
+        mock_load_calib.return_value.modelset.calibration.comparison[0].observed_location_column = "location"
+        mock_load_calib.return_value.modelset.calibration.comparison[0].observed_location_format = "ISO"
+        mock_load_calib.return_value.modelset.calibration.comparison[0].observed_date_column = "date"
+
+        mock_codebook.return_value = pd.DataFrame({"location_name_epydemix": ["California", "Texas", "New York"]})
+
+        mock_read_csv.return_value = pd.DataFrame({"col": [1]})
+        mock_get_window.return_value = pd.DataFrame({"col": [1]})
+
+        with patch("epymodelingsuite.schema.data_validation.get_data_in_location") as mock_get_location:
+            mock_get_location.return_value = pd.DataFrame({"col": [1], "date": ["2024-01-01"]})
+
+            success, error = validate_calibration_data_for_config_set(
+                "basemodel.yml",
+                "calibration.yml",
+            )
+
+        assert success is True
+        assert error is None
+        # Verify codebook was called to expand 'all'
+        mock_codebook.assert_called_once()


### PR DESCRIPTION
## Summary
Closes #201

Adds data validation to detect missing/incomplete calibration data early, before wasting compute on calibration jobs that will fail.

## Changes
- Add `epymodelingsuite/schema/data_validation.py` with two validation functions:
  - `validate_calibration_data()` - core validation for in-memory objects
  - `validate_calibration_data_for_config_set()` - file-path wrapper for external scripts
- Add `CalibrationDataError` exception in `dispatcher/builder.py`
- Integrate validation into `build_calibration()` with `skip_invalid_locations` parameter
- Log warnings for incomplete data coverage (data doesn't span full fitting window)

## Usage

```python
# From external scripts (e.g., validate_configs.py)
from epymodelingsuite.schema import validate_calibration_data_for_config_set

ok, err = validate_calibration_data_for_config_set("basemodel.yml", "calibration.yml")
if not ok:
    print(f"Validation failed: {err}")
```