### PR TITLE
Fix inPrev calculation to migrate to pandas 3.0

### DIFF
--- a/epymodelingsuite/school_closures.py
+++ b/epymodelingsuite/school_closures.py
@@ -98,10 +98,9 @@ def make_school_closure_dict(
         # Sort table
         tmp = df.sort_values(by=[cat, start_str]).reset_index(drop=True)
         # Create a new column 'InPrev' thats true for all rows > 0, if start time at Event_(X) > end time at Event_(X-1)
+        # Use shift() to compare current row's start with previous row's end
+        tmp["InPrev"] = tmp[start_str] > tmp[end_str].shift(1)
         tmp.loc[0, "InPrev"] = False
-        tmp.InPrev.to_numpy()[1:] = tmp.loc[1:, start_str].reset_index(drop=True) > tmp.loc[
-            : (len(tmp) - 2), end_str
-        ].reset_index(drop=True)
         tmp["InPrev"] = tmp["InPrev"].astype("bool")
         # Create a new column 'GrpCount' that creates a cumulative sum of all 'InPrev' column bools
         # If 'GrpCount' does not change value between subsequent rows, these rows will be grouped into a single interval


### PR DESCRIPTION
## Problem
With the release of Pandas 3.0, school closure is giving errors:
```
Traceback (most recent call last):
  File "/scripts/main_builder.py", line 169, in main
    num_files = build_and_save_dispatch_outputs(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scripts/main_builder.py", line 66, in build_and_save_dispatch_outputs
    outputs = dispatch_builder(**dispatch_kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/epymodelingsuite/epymodelingsuite/dispatcher/builder.py", line 621, in dispatch_builder
    builder_outputs = BUILDER_REGISTRY[kinds](**configs)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/epymodelingsuite/epymodelingsuite/dispatcher/builder.py", line 460, in build_calibration
    models = setup_interventions(models, basemodel, intervention_types, sampled_start_timespan)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/epymodelingsuite/epymodelingsuite/builders/orchestrators.py", line 225, in setup_interventions
    closure_dict = make_school_closure_dict(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/epymodelingsuite/epymodelingsuite/school_closures.py", line 189, in make_school_closure_dict
    closure_reduced = reduction_loop(closure_synthetic, interval_reduction_iter, "name", "start", "end", DEBUG=0)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/epymodelingsuite/epymodelingsuite/school_closures.py", line 124, in reduction_loop
    red_df = reduce_intervals(df_synthetic, cat, start_str, end_str)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/epymodelingsuite/epymodelingsuite/school_closures.py", line 102, in reduce_intervals
    tmp.InPrev.to_numpy()[1:] = tmp.loc[1:, start_str].reset_index(drop=True) > tmp.loc[
    ~~~~~~~~~~~~~~~~~~~~~^^^^
ValueError: assignment destination is read-only
```

This is due to the introduction of ["Copy-on-Write" beehavior](https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#consistent-copy-view-behaviour-with-copy-on-write), where
`df.InPrev.to_numpy()` returns a read-only copy.

## Fix
Use shift() from pandas.