### PR TITLE
Use RI from initial conditions in parameter calculation

### DIFF
--- a/epymodelingsuite/builders/base.py
+++ b/epymodelingsuite/builders/base.py
@@ -338,6 +338,7 @@ def calculate_parameters_from_config(
     # Build a dictionary of calculated values
     parameters_dict = {}
     for name, expr in calc_params.items():
+        parameter_dict = {}
         logger.info(f"Calculating parameter {name} using expression: {expr}")
         try:
             # Parse the expression into a tree
@@ -351,18 +352,18 @@ def calculate_parameters_from_config(
 
             # Evaluate the expression
             code = compile(tree, filename="<calc_eval>", mode="eval")
-            parameters_dict[name] = eval(code, {"__builtins__": None, "np": np, "scipy": scipy}, {})
-            logger.info(f"Calculated parameter {name}: {parameters_dict[name]}")
+            parameter_dict[name] = eval(code, {"__builtins__": None, "np": np, "scipy": scipy}, {})
+            logger.info(f"Calculated parameter {name}: {parameter_dict[name]}")
         except Exception as e:
             raise ValueError(f"Error calculating parameter {name}: {e}")
 
-    try:
-        model.add_parameter(parameters_dict=parameters_dict)
-        logger.info(f"Calculated parameters: {list(parameters_dict.keys())}")
+        try:
+            model.add_parameter(parameters_dict=parameter_dict)
+            logger.info(f"Added parameters: {list(parameter_dict.keys())}")
+        except Exception as e:
+            raise ValueError(f"Error adding parameters to model: {e}")
 
-        return model
-    except Exception as e:
-        raise ValueError(f"Error adding parameters to model: {e}")
+    return model
 
 
 def calculate_compartment_initial_conditions(

--- a/epymodelingsuite/builders/base.py
+++ b/epymodelingsuite/builders/base.py
@@ -336,7 +336,6 @@ def calculate_parameters_from_config(
     calc_params = {name: param.value for name, param in parameters.items() if param.type == "calculated"}
 
     # Build a dictionary of calculated values
-    parameters_dict = {}
     for name, expr in calc_params.items():
         parameter_dict = {}
         logger.info(f"Calculating parameter {name} using expression: {expr}")

--- a/epymodelingsuite/builders/base.py
+++ b/epymodelingsuite/builders/base.py
@@ -311,18 +311,26 @@ def add_model_parameters_from_config(model: EpiModel, parameters: dict[str, Para
         raise ValueError(f"Error adding parameters to model: {e}")
 
 
-def calculate_parameters_from_config(model: EpiModel, parameters: dict[str, Parameter]) -> EpiModel:
+def calculate_parameters_from_config(
+    model: EpiModel, parameters: dict[str, Parameter], compartment_init: dict[str, np.ndarray] | None
+) -> EpiModel:
     """
     Add calculated parameters to the EpiModel, assuming all non-calculated parameters are already in the model.
 
     Parameters
     ----------
-        model: The EpiModel instance to which calculated parameters will be added.
-        parameters: Dictionary mapping parameter names to Parameter objects.
+    model: EpiModel
+            The EpiModel instance to which calculated parameters will be added.
+    parameters: dict[str, Parameter]
+            Dictionary mapping parameter names to Parameter objects.
+    compartment_init: dict[str, np.ndarray] | None
+            Dictionary mapping compartment names to initial condition arrays,
+            or None if no initial conditions are specified.
 
     Returns
     -------
-        EpiModel instance with calculated parameters added.
+    EpiModel
+            EpiModel instance with calculated parameters added.
     """
     # Extract parameter names and expressions
     calc_params = {name: param.value for name, param in parameters.items() if param.type == "calculated"}
@@ -336,7 +344,7 @@ def calculate_parameters_from_config(model: EpiModel, parameters: dict[str, Para
             tree = ast.parse(expr, mode="eval")
 
             # Substitute retrieved parameter values or contact matrix eigenvalue into the tree
-            RetrieveName(model).visit(tree)
+            RetrieveName(model, compartment_init).visit(tree)
 
             # Validate the expression
             SafeEvalVisitor().visit(tree)
@@ -361,7 +369,7 @@ def calculate_compartment_initial_conditions(
     compartments: list,
     population_array: np.ndarray,
     params_dict: dict | None = None,
-) -> dict | None:
+) -> dict[str, np.ndarray] | None:
     """
     Calculate initial conditions for compartments based on their initialization values.
 
@@ -385,15 +393,14 @@ def calculate_compartment_initial_conditions(
 
     Returns
     -------
-    dict | None
+    dict[str, np.ndarray] | None
         Dictionary mapping compartment names to initial condition arrays,
         or None if no initial conditions are specified.
 
     Raises
     ------
     ValueError
-        If multiple compartments are marked as default, or if initialization
-        logic produces invalid values.
+        If initialization logic produces invalid values.
 
     Examples
     --------

--- a/epymodelingsuite/builders/base.py
+++ b/epymodelingsuite/builders/base.py
@@ -358,7 +358,7 @@ def calculate_parameters_from_config(
 
         try:
             model.add_parameter(parameters_dict=parameter_dict)
-            logger.info(f"Added parameters: {list(parameter_dict.keys())}")
+            logger.info(f"Added parameter: {list(parameter_dict.keys())}")
         except Exception as e:
             raise ValueError(f"Error adding parameters to model: {e}")
 

--- a/epymodelingsuite/builders/orchestrators.py
+++ b/epymodelingsuite/builders/orchestrators.py
@@ -664,6 +664,7 @@ def apply_calibrated_parameters(
     model: EpiModel,
     params: dict,
     parameter_config: dict[str, Parameter],
+    compartment_init: dict[str, np.ndarray] | None,
 ) -> None:
     """
     Apply calibrated and calculated parameters to model.
@@ -679,6 +680,9 @@ def apply_calibrated_parameters(
             Dictionary containing calibrated parameter values from ABC sampler.
     parameter_config : dict[str, Parameter]
             Parameter configuration from basemodel.
+    compartment_init: dict[str, np.ndarray] | None
+            Dictionary mapping compartment names to initial condition arrays,
+            or None if no initial conditions are specified.
     """
     # Extract calibrated parameters
     calibrated_params = {
@@ -693,7 +697,7 @@ def apply_calibrated_parameters(
     # Recalculate derived parameters if any exist
     has_calculated = any(param.type.value == "calculated" for param in parameter_config.values())
     if has_calculated:
-        calculate_parameters_from_config(model, parameter_config)
+        calculate_parameters_from_config(model=model, parameters=parameter_config, compartment_init=compartment_init)
 
 
 def compute_simulation_start_date(
@@ -876,10 +880,20 @@ def make_simulate_wrapper(
             reference_start_date=reference_start_date,
         )
         timespan = Timespan(start_date=start_date, end_date=params["end_date"], delta_t=basemodel.timespan.delta_t)
-        # 3. Apply calibrated parameters
-        apply_calibrated_parameters(model=model, params=params, parameter_config=basemodel.parameters)
 
-        # 4. Apply vaccination (reaggregating if start_date is sampled)
+        # 3. Calculate compartment initial conditions
+        compartment_init = calculate_compartment_initial_conditions(
+            compartments=basemodel.compartments,
+            population_array=model.population.Nk,
+            params_dict=params,
+        )
+
+        # 4. Apply calibrated parameters
+        apply_calibrated_parameters(
+            model=model, params=params, parameter_config=basemodel.parameters, compartment_init=compartment_init
+        )
+
+        # 5. Apply vaccination (reaggregating if start_date is sampled)
         apply_vaccination_for_sampled_start(
             model=model,
             basemodel=basemodel,
@@ -888,23 +902,16 @@ def make_simulate_wrapper(
             sampled_start_timespan=sampled_start_timespan,
         )
 
-        # 5. Apply seasonality (this must occur before parameter interventions to preserve parameter overrides)
+        # 6. Apply seasonality (this must occur before parameter interventions to preserve parameter overrides)
         apply_seasonality_with_sampled_min(model=model, basemodel=basemodel, timespan=timespan, params=params)
 
-        # 6. Add parameter interventions
+        # 7. Add parameter interventions
         if basemodel.interventions and "parameter" in intervention_types:
             add_parameter_interventions_from_config(
                 model=model, interventions=basemodel.interventions, timespan=timespan
             )
 
-        # 7. Calculate compartment initial conditions
-        compartment_init = calculate_compartment_initial_conditions(
-            compartments=basemodel.compartments,
-            population_array=model.population.Nk,
-            params_dict=params,
-        )
-
-        # 8 Handle random state
+        # 8. Handle random state
         if "random_state" in params.keys():
             rng.bit_generator.state = params["random_state"]
         random_state = rng.bit_generator.state

--- a/epymodelingsuite/dispatcher/builder.py
+++ b/epymodelingsuite/dispatcher/builder.py
@@ -329,12 +329,21 @@ def build_sampling(
                 delta_t=basemodel.timespan.delta_t,
             )
 
+            # Initial conditions
+            compartment_init = calculate_compartment_initial_conditions(
+                compartments=basemodel.compartments,
+                population_array=m.population.Nk,
+                params_dict=varset.get("compartments"),
+            )
+
             # Sampled/calculated parameters
             if "parameters" in varset.keys():
                 parameters = {k: Parameter(type="scalar", value=v) for k, v in varset["parameters"].items()}
                 add_model_parameters_from_config(m, parameters)
             if "calculated" in [param_args.type.value for param, param_args in (basemodel.parameters).items()]:
-                calculate_parameters_from_config(m, basemodel.parameters)
+                calculate_parameters_from_config(
+                    model=m, parameters=basemodel.parameters, compartment_init=compartment_init
+                )
 
             # Vaccination (if start_date is sampled)
             if basemodel.vaccination and sampled_start_timespan:
@@ -350,13 +359,6 @@ def build_sampling(
             # Parameter interventions
             if basemodel.interventions and "parameter" in intervention_types:
                 add_parameter_interventions_from_config(m, basemodel.interventions, timespan)
-
-            # Initial conditions
-            compartment_init = calculate_compartment_initial_conditions(
-                compartments=basemodel.compartments,
-                population_array=m.population.Nk,
-                params_dict=varset.get("compartments"),
-            )
 
             sim_args = SimulationArguments(
                 start_date=timespan.start_date,

--- a/epymodelingsuite/dispatcher/builder.py
+++ b/epymodelingsuite/dispatcher/builder.py
@@ -199,10 +199,16 @@ def build_basemodel(*, basemodel_config: BasemodelConfig, **_) -> BuilderOutput:
     if basemodel.vaccination:
         add_vaccination_schedules_from_config(model, basemodel.transitions, basemodel.vaccination, basemodel.timespan)
 
+    # Initial conditions
+    compartment_inits = calculate_compartment_initial_conditions(
+        compartments=basemodel.compartments,
+        population_array=model.population.Nk,
+    )
+
     # Parameters
     add_model_parameters_from_config(model, basemodel.parameters)
     if "calculated" in [param_args.type.value for param, param_args in (basemodel.parameters).items()]:
-        calculate_parameters_from_config(model, basemodel.parameters)
+        calculate_parameters_from_config(model, basemodel.parameters, compartment_inits)
 
     # Seasonality (this must occur before interventions to preserve parameter overrides)
     if basemodel.seasonality:
@@ -226,12 +232,6 @@ def build_basemodel(*, basemodel_config: BasemodelConfig, **_) -> BuilderOutput:
         # Parameter
         if "parameter" in intervention_types:
             add_parameter_interventions_from_config(model, basemodel.interventions, basemodel.timespan)
-
-    # Initial conditions
-    compartment_inits = calculate_compartment_initial_conditions(
-        compartments=basemodel.compartments,
-        population_array=model.population.Nk,
-    )
 
     simulation_args = SimulationArguments(
         start_date=basemodel.timespan.start_date,

--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -24,7 +24,6 @@ from ..utils.location import (
     convert_location_name_format,
     parse_population_name,
 )
-from ..utils.populations import get_total_population
 from ..visualization.generators import (
     generate_categorical_plots,
     generate_posterior_grid_plot,

--- a/epymodelingsuite/utils/expression_eval.py
+++ b/epymodelingsuite/utils/expression_eval.py
@@ -160,16 +160,19 @@ class SafeEvalVisitor(ast.NodeVisitor):
 
 class RetrieveName(ast.NodeTransformer):
     """
-    A NodeTransformer for substituting terms in an expression with parameter values or contact matrix eigenvalue from an EpiModel.
+    A NodeTransformer for substituting terms in an expression with parameter values or contact matrix eigenvalue from an EpiModel,
+    or .
     Used for calculated parameters.
-    Constructor requires an EpiModel with contact matrices.
+    Constructor requires an EpiModel with contact matrices, and optionally a dict with initial conditions.
     """
 
-    def __init__(self, model: EpiModel):
+    def __init__(self, model: EpiModel, compartment_init: dict[str, np.ndarray] | None):
         self.model = model
+        self.compartment_init = compartment_init
 
     def visit_Name(self, node):
         if node.id not in _allowed_modules:
+            # Eigenvalue of contact matrix
             if node.id == "eigenvalue":
                 try:
                     C = np.sum([c for _, c in self.model.population.contact_matrices.items()], axis=0)
@@ -177,6 +180,27 @@ class RetrieveName(ast.NodeTransformer):
                     return ast.fix_missing_locations(ast.Constant(value=float(eigenvalue)))
                 except Exception as e:
                     raise ValueError(f"Error calculating eigenvalue of contact matrix: {e}")
+
+            # Proportion of population in compartment from initial conditions
+            elif node.id in self.model.compartments:
+                if self.compartment_init is None:
+                    raise ValueError(
+                        f"Parameter calculation received compartment id {node.id} but initial conditions were not provided."
+                    )
+                if node.id not in self.compartment_init:
+                    raise ValueError(
+                        f"Parameter calculation received compartment id {node.id} but compartment is missing from provided initial conditions."
+                    )
+                try:
+                    init_count = self.compartment_init.get(node.id).sum()
+                    proportion = init_count / model.population.Nk.sum()
+                    return ast.fix_missing_locations(ast.Constant(value=float(proportion)))
+                except Exception as e:
+                    raise ValueError(
+                        f"Error calculating proportion of population in compartment from initial conditions: {e}"
+                    )
+
+            # Model parameter
             else:
                 try:
                     value = self.model.get_parameter(node.id)

--- a/epymodelingsuite/utils/expression_eval.py
+++ b/epymodelingsuite/utils/expression_eval.py
@@ -193,11 +193,11 @@ class RetrieveName(ast.NodeTransformer):
                     )
                 try:
                     init_count = self.compartment_init.get(node.id).sum()
-                    proportion = init_count / model.population.Nk.sum()
+                    proportion = init_count / self.model.population.Nk.sum()
                     return ast.fix_missing_locations(ast.Constant(value=float(proportion)))
                 except Exception as e:
                     raise ValueError(
-                        f"Error calculating proportion of population in compartment from initial conditions: {e}"
+                        f"Error calculating proportion of population in compartment{node.id} from initial conditions: {e}"
                     )
 
             # Model parameter

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -22,15 +22,15 @@ from ..schema.output import (
     QuantilesOutputTypeEnum,
 )
 from .core import (
-    format_location_name,
-    sort_locations_by_state,
     figure_to_output_object,
+    format_location_name,
     plot_calibration_projection,
     plot_calibration_projection_grid,
     plot_calibration_projection_sidebyside,
     plot_categorical_stacked_bars_multihorizon,
     plot_posterior_histogram,
     plot_posterior_histogram_grid,
+    sort_locations_by_state,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/builders/test_base.py
+++ b/tests/builders/test_base.py
@@ -481,7 +481,7 @@ class TestParseAgeGroup:
         """Test parsing '0+' which represents all ages."""
         result = _parse_age_group("0+")
         # Should return ["0", "1", ..., "83", "84+"]
-        expected = [str(i) for i in range(0, 84)] + ["84+"]
+        expected = [str(i) for i in range(84)] + ["84+"]
         assert result == expected
         assert len(result) == 85  # 0-83 (84 ages) + "84+"
 

--- a/tests/schema/test_calibration.py
+++ b/tests/schema/test_calibration.py
@@ -6,7 +6,6 @@ import pytest
 
 from epymodelingsuite.schema.calibration import (
     CalibrationConfig,
-    CalibrationModelset,
     CalibrationStrategy,
     ComparisonSpec,
 )

--- a/tests/utils/test_populations.py
+++ b/tests/utils/test_populations.py
@@ -57,7 +57,7 @@ class TestAggregatePopulationByAgeGroups:
 
     def test_dict_input(self):
         """Test aggregation with dict input."""
-        pop_dict = {i: 100 for i in range(10)}  # ages 0-9, 100 each
+        pop_dict = dict.fromkeys(range(10), 100)  # ages 0-9, 100 each
 
         result = aggregate_population_by_age_groups(pop_dict, ["0-4", "5+"])
 


### PR DESCRIPTION
### Overview

Permits using compartment IDs in expressions for calculated parameters.

Compartment IDs are resolved to the proportion of model population placed in the compartment by initial conditions.

Sensitive to order of parameter declaration in basemodel, throws error if a calculated field dependent on another calculated field is declared before that field.

### Usage

Keep treating RI as a compartment initialization (e.g. `Initial_immune`) which can be scalar, age-stratified, sampled, or calibrated.

Avoid re-using names between parameters and compartments (noted in #156).

Example for flu model:
Sample `Initial_immune` compartment initialization (RI) and `Reff` in calibration.
Define `Initial_immune` in basemodel compartments.
In basemodel parameters declaration,
define `Reff: calibrated`
define `R0:  Reff / (1 - Initial_immune)`
define `beta: R0*mu/(eigenvalue*(1-p_asymp+p_asymp*r_beta_asymp))`
R0 must be defined before beta to avoid calculation error.

### Changes

#### `builders/orchestrators.py`
- `make_simulate_wrapper` move step 7 before step 3, pass `compartment_init` through `apply_calibrated_parameters` to `calculate_parameters_from_config`

#### `dispatcher/builder.py`
- `build_sampling` move init above params, pass `compartment_init` to `calculate_parameters_from_config`

#### `builders/base.py`
- `calculate_parameters_from_config` pass compartment init to visitor

#### `utils/expression_eval.py`
- `RetrieveName.visit_Name()` use compartment init and model population to calculate proportion

### TODO

Investigate failed pytest tests:
```
FAILED tests/builders/test_orchestrators.py::TestApplyCalibratedParameters::test_applies_calibrated_parameters - TypeError: apply_calibrated_parameters() missing 1 required positional argu...
FAILED tests/builders/test_orchestrators.py::TestApplyCalibratedParameters::test_no_calibrated_parameters_skips_add - TypeError: apply_calibrated_parameters() missing 1 required positional argu...
FAILED tests/builders/test_orchestrators.py::TestApplyCalibratedParameters::test_recalculates_derived_parameters - TypeError: apply_calibrated_parameters() missing 1 required positional argu...
```