### PR TITLE
Fix metrocast submission horizons

### DIFF
--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -17,6 +17,7 @@ from ..schema.output import (
     OutputConfig,
     OutputObject,
     TabularOutputTypeEnum,
+    get_metrocast_horizons,
     get_metrocast_quantiles,
 )
 from ..telemetry import ExecutionTelemetry
@@ -210,7 +211,10 @@ def filter_failed_calibration_trajectories(calibration_results: CalibrationResul
 
 
 def format_quantiles_flusightforecast(
-    quantiles_df: pd.DataFrame, reference_date: date, target: str = "wk inc flu hosp"
+    quantiles_df: pd.DataFrame,
+    reference_date: date,
+    target: str = "wk inc flu hosp",
+    metrocast: bool = False,
 ) -> pd.DataFrame:
     """
     Create FluSight forecast formatted quantile outputs for a single model. Rate-trends are handled separately.
@@ -223,6 +227,8 @@ def format_quantiles_flusightforecast(
         Reference date for calculating forecast horizons
     target : str
         Target name for the submission file (default: "wk inc flu hosp")
+    metrocast : bool
+        Use horizons for metrocast (0-3) instead of standard FluSight horizons (-1 to 3)
 
     Returns
     -------
@@ -231,8 +237,8 @@ def format_quantiles_flusightforecast(
     """
     formatted = copy.deepcopy(quantiles_df)
 
-    # Horizons required for quantile outputs
-    flusight_horizons = range(-1, 4)
+    # Horizons required for quantile outputs (metrocast excludes horizon -1)
+    horizons = get_metrocast_horizons() if metrocast else range(-1, 4)
 
     # Create horizon column and filter for appropriate horizons
     formatted.insert(
@@ -240,7 +246,7 @@ def format_quantiles_flusightforecast(
         "horizon",
         (formatted.date - pd.to_datetime(reference_date)).apply(lambda x: x / np.timedelta64(1, "W")).astype(int),
     )
-    formatted = formatted[formatted.horizon.isin(flusight_horizons)]
+    formatted = formatted[formatted.horizon.isin(horizons)]
 
     # Name and format remaining fields
     # FRAGILE: the name 'hospitalizations' is user-supplied in the modelset as the column to look for in the surveillance data.
@@ -774,7 +780,7 @@ def make_prop_ed_flusightforecast(
             formatted = copy.deepcopy(projection_quantiles)
 
             # Horizons required for quantile outputs
-            horizons = range(4) if metrocast == True else range(-1, 4)
+            horizons = get_metrocast_horizons() if metrocast else range(-1, 4)
 
             # Get the reference date from parameter or pred_hosp
             if reference_date is None:
@@ -1430,6 +1436,7 @@ def generate_calibration_outputs(
                     quanf_df,
                     output.flusight_format.reference_date,
                     target=output.flusight_format.hospitalizations.target,
+                    metrocast=output.flusight_format.metrocast,
                 )
                 quanf_df.insert(0, "reference_date", output.flusight_format.reference_date)
                 quanf_df.insert(0, "location", get_hub_location_id(calibration.population))
@@ -1496,6 +1503,7 @@ def generate_calibration_outputs(
                     quantiles_calibration_flusight,
                     quantiles_projection_flusight,
                     output.flusight_format.reference_date,
+                    metrocast=output.flusight_format.metrocast,
                 )
                 hub_format_output_list.append(prop_ed_df)
             except (ValueError, AssertionError, KeyError, IndexError) as e:

--- a/epymodelingsuite/schema/output.py
+++ b/epymodelingsuite/schema/output.py
@@ -117,6 +117,15 @@ def get_metrocast_quantiles() -> list[float]:
     ]
 
 
+def get_metrocast_horizons() -> range:
+    """
+    Return the forecast horizons for metrocast submissions.
+
+    Metrocast uses horizons 0-3, while standard FluSight uses -1 to 3.
+    """
+    return range(4)
+
+
 def get_quantile_ribbon_default() -> list[float]:
     """Return a list containing default quantiles for plotting ribbons."""
     return [0.025, 0.25, 0.5, 0.75, 0.975]

--- a/tests/dispatcher/test_output.py
+++ b/tests/dispatcher/test_output.py
@@ -453,3 +453,97 @@ class TestGetPlotLocationLabel:
         # NC flu region
         result = get_plot_location_label("metrocast_location_nenc")
         assert result == "Northeastern, NC"
+
+
+class TestFormatQuantilesFlusightforecast:
+    """Tests for format_quantiles_flusightforecast function."""
+
+    @pytest.fixture
+    def sample_quantiles_df(self):
+        """Create sample quantiles DataFrame spanning horizons -1 to 3."""
+        reference_date = date(2025, 11, 29)  # Saturday
+        # Create dates for horizons -1, 0, 1, 2, 3 (each 7 days apart)
+        dates = [
+            pd.Timestamp("2025-11-22"),  # horizon -1
+            pd.Timestamp("2025-11-29"),  # horizon 0
+            pd.Timestamp("2025-12-06"),  # horizon 1
+            pd.Timestamp("2025-12-13"),  # horizon 2
+            pd.Timestamp("2025-12-20"),  # horizon 3
+        ]
+        quantiles = [0.25, 0.5, 0.75]
+        data = []
+        for d in dates:
+            for q in quantiles:
+                data.append({"date": d, "quantile": q, "hospitalizations": 100.0})
+        return pd.DataFrame(data), reference_date
+
+    def test_standard_flusight_includes_horizon_minus_one(self, sample_quantiles_df):
+        """Test that standard FluSight (metrocast=False) includes horizon -1."""
+        from epymodelingsuite.dispatcher.output import format_quantiles_flusightforecast
+
+        df, reference_date = sample_quantiles_df
+        result = format_quantiles_flusightforecast(df, reference_date, metrocast=False)
+
+        horizons = result["horizon"].unique()
+        assert -1 in horizons
+        assert set(horizons) == {-1, 0, 1, 2, 3}
+
+    def test_metrocast_excludes_horizon_minus_one(self, sample_quantiles_df):
+        """Test that metrocast=True excludes horizon -1."""
+        from epymodelingsuite.dispatcher.output import format_quantiles_flusightforecast
+
+        df, reference_date = sample_quantiles_df
+        result = format_quantiles_flusightforecast(df, reference_date, metrocast=True)
+
+        horizons = result["horizon"].unique()
+        assert -1 not in horizons
+        assert set(horizons) == {0, 1, 2, 3}
+
+    def test_output_has_correct_columns(self, sample_quantiles_df):
+        """Test that output DataFrame has correct FluSight columns."""
+        from epymodelingsuite.dispatcher.output import format_quantiles_flusightforecast
+
+        df, reference_date = sample_quantiles_df
+        result = format_quantiles_flusightforecast(df, reference_date)
+
+        expected_columns = {"horizon", "target", "output_type", "output_type_id", "target_end_date", "value"}
+        assert set(result.columns) == expected_columns
+
+    def test_output_type_is_quantile(self, sample_quantiles_df):
+        """Test that output_type column is 'quantile' for all rows."""
+        from epymodelingsuite.dispatcher.output import format_quantiles_flusightforecast
+
+        df, reference_date = sample_quantiles_df
+        result = format_quantiles_flusightforecast(df, reference_date)
+
+        assert (result["output_type"] == "quantile").all()
+
+    def test_custom_target_name(self, sample_quantiles_df):
+        """Test that custom target name is used."""
+        from epymodelingsuite.dispatcher.output import format_quantiles_flusightforecast
+
+        df, reference_date = sample_quantiles_df
+        custom_target = "custom target name"
+        result = format_quantiles_flusightforecast(df, reference_date, target=custom_target)
+
+        assert (result["target"] == custom_target).all()
+
+    def test_default_target_name(self, sample_quantiles_df):
+        """Test that default target name is 'wk inc flu hosp'."""
+        from epymodelingsuite.dispatcher.output import format_quantiles_flusightforecast
+
+        df, reference_date = sample_quantiles_df
+        result = format_quantiles_flusightforecast(df, reference_date)
+
+        assert (result["target"] == "wk inc flu hosp").all()
+
+    def test_hospitalizations_rounded_to_integer(self, sample_quantiles_df):
+        """Test that hospitalization values are rounded to integers."""
+        from epymodelingsuite.dispatcher.output import format_quantiles_flusightforecast
+
+        df, reference_date = sample_quantiles_df
+        # Modify to have non-integer values
+        df["hospitalizations"] = 100.7
+        result = format_quantiles_flusightforecast(df, reference_date)
+
+        assert (result["value"] == 101).all()


### PR DESCRIPTION
## Overview

When `metrocast: true` is set in the output configuration, submission files were incorrectly including horizon -1. Metrocast submissions [should only include horizons 0-3.](https://github.com/reichlab/flu-metrocast/tree/main/model-output#horizon)

Closes #226 

## Changes made

- Added `get_metrocast_horizons()` helper function in `schema/output.py`
- Added `metrocast` parameter to `format_quantiles_flusightforecast()` to filter horizons appropriately
- Fixed missing `metrocast` parameter in calls to `format_quantiles_flusightforecast()` and `make_prop_ed_flusightforecast()`
- Added tests for `format_quantiles_flusightforecast()` covering both standard and metrocast horizon filtering