### PR TITLE
Switch epydemix dependency to GitHub fork

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "Models and calibrators for forecasting and scenario modeling. A codebase for large workloads with epydemix and expanded functionality."
 dependencies = [
-    "epydemix",
+    "epydemix @ git+https://github.com/mobs-lab/epydemix.git",
     "pandas",
     "numpy",
     "scipy",

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -695,9 +695,7 @@ epiweeks==2.4.0 ; python_full_version >= '3.10' \
     --hash=sha256:0096132a50cfc4b52b2bfc8cf841d278740414d01cac303df05146db8b526539 \
     --hash=sha256:a40cdde09b47530e7703d3d75248bb4ae2eb340f23af7c4c50e708b2e733e101
     # via epymodelingsuite
-epydemix==1.0.2 \
-    --hash=sha256:09a67c7478723ce27d903b0ac4acee5a6834bda5ef6166e6e2848e2aaa66aee9 \
-    --hash=sha256:90633fa5b3329fef9db7d62361108cc5771c9b5d035b7a9253f50275b5b70684
+epydemix @ git+https://github.com/mobs-lab/epydemix.git@0cf233958a9ad4e65f8fbffad1bddef7211b65a6
     # via epymodelingsuite
 evalidate==2.1.3 \
     --hash=sha256:5c0b806fa12c5c029a26e5f69f02d4dedc00bbbe9dbfaafdb99d4f538a841438 \

--- a/uv.lock
+++ b/uv.lock
@@ -950,7 +950,7 @@ wheels = [
 [[package]]
 name = "epydemix"
 version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/mobs-lab/epydemix.git#0cf233958a9ad4e65f8fbffad1bddef7211b65a6" }
 dependencies = [
     { name = "evalidate" },
     { name = "matplotlib", version = "3.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -965,10 +965,6 @@ dependencies = [
     { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "seaborn" },
     { name = "setuptools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/95/9c/597ece0120b4a41585b49f9c0c7888da97276b484182b2e6301e74da9900/epydemix-1.0.2.tar.gz", hash = "sha256:90633fa5b3329fef9db7d62361108cc5771c9b5d035b7a9253f50275b5b70684", size = 97939, upload-time = "2025-10-30T13:45:04.915Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/19/73c7ba741aec09b1b4608035144f4c61a1ccd417708a5266ea12d430964e/epydemix-1.0.2-py3-none-any.whl", hash = "sha256:09a67c7478723ce27d903b0ac4acee5a6834bda5ef6166e6e2848e2aaa66aee9", size = 102611, upload-time = "2025-10-30T13:45:03.929Z" },
 ]
 
 [[package]]
@@ -1020,7 +1016,7 @@ dev = [
 requires-dist = [
     { name = "autodoc-pydantic", marker = "extra == 'dev'" },
     { name = "epiweeks" },
-    { name = "epydemix" },
+    { name = "epydemix", git = "https://github.com/mobs-lab/epydemix.git" },
     { name = "holidays" },
     { name = "ipykernel", marker = "extra == 'dev'" },
     { name = "matplotlib" },


### PR DESCRIPTION
## Summary
- Change epydemix dependency from PyPI to GitHub fork at https://github.com/mobs-lab/epydemix
- Update lock files to use git source
- This add support to epydemix for ignoring NaN in quantile calculation (but additional changes are needed in the suite)