### PR TITLE
Add ignore_nan=True to get_calibration_quantiles calls

### DIFF
--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -1166,7 +1166,10 @@ def generate_calibration_outputs(
                     for generation in output.quantiles.calibration:
                         try:
                             quancal_df = calibration.results.get_calibration_quantiles(
-                                quantiles=output.quantiles.selections, generation=generation, variables=["data", "date"]
+                                quantiles=output.quantiles.selections,
+                                generation=generation,
+                                variables=["data", "date"],
+                                ignore_nan=True,
                             )
                             quancal_df.insert(0, "primary_id", calibration.primary_id)
                             quancal_df.insert(1, "seed", calibration.seed)
@@ -1180,7 +1183,9 @@ def generate_calibration_outputs(
                 else:
                     try:
                         quancal_df = calibration.results.get_calibration_quantiles(
-                            quantiles=output.quantiles.selections, variables=["data", "date"]
+                            quantiles=output.quantiles.selections,
+                            variables=["data", "date"],
+                            ignore_nan=True,
                         )
                         quancal_df.insert(0, "primary_id", calibration.primary_id)
                         quancal_df.insert(1, "seed", calibration.seed)
@@ -1449,7 +1454,9 @@ def generate_calibration_outputs(
                 for calibration in calibrations:
                     try:
                         quancalflu_df = calibration.results.get_calibration_quantiles(
-                            quantiles=flusight_quantiles, variables=["data", "date"]
+                            quantiles=flusight_quantiles,
+                            variables=["data", "date"],
+                            ignore_nan=True,
                         )
                         quancalflu_df.insert(0, "primary_id", calibration.primary_id)
                         quancalflu_df.insert(1, "seed", calibration.seed)


### PR DESCRIPTION
## Summary
- Add `ignore_nan=True` parameter to all `get_calibration_quantiles` calls in output generation to handle NaN values gracefully