### PR TITLE
Add ignore_nan=True to all quantile calls

### DIFF
--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -958,7 +958,9 @@ def generate_simulation_outputs(
         for simulation in simulations:
             # Compartments
             if output.quantiles.compartments:
-                quanc_df = simulation.results.get_quantiles_compartments(quantiles=output.quantiles.selections)
+                quanc_df = simulation.results.get_quantiles_compartments(
+                    quantiles=output.quantiles.selections, ignore_nan=True
+                )
                 if hasattr(output.quantiles.compartments, "__len__"):
                     try:
                         columns_to_select = ["date", "quantile"]
@@ -975,7 +977,9 @@ def generate_simulation_outputs(
 
             # Transitions
             if output.quantiles.transitions:
-                quant_df = simulation.results.get_quantiles_transitions(quantiles=output.quantiles.selections)
+                quant_df = simulation.results.get_quantiles_transitions(
+                    quantiles=output.quantiles.selections, ignore_nan=True
+                )
                 if hasattr(output.quantiles.transitions, "__len__"):
                     try:
                         columns_to_select = ["date", "quantile"]
@@ -1203,7 +1207,9 @@ def generate_calibration_outputs(
 
             # Projection quantiles
             try:
-                quan_df = calibration.results.get_projection_quantiles(quantiles=output.quantiles.selections)
+                quan_df = calibration.results.get_projection_quantiles(
+                    quantiles=output.quantiles.selections, ignore_nan=True
+                )
             except ValueError:
                 warnings.add(
                     f"OUTPUT GENERATOR: failed to obtain projection quantiles for model with primary_id={calibration.primary_id}, continuing to next model."
@@ -1429,7 +1435,9 @@ def generate_calibration_outputs(
                 try:
                     # FRAGILE: the name 'hospitalizations' is user-supplied in the modelset as the column to look for in the surveillance data.
                     quanf_df = calibration.results.get_projection_quantiles(
-                        quantiles=flusight_quantiles, variables=["date", "quantile", "hospitalizations"]
+                        quantiles=flusight_quantiles,
+                        variables=["date", "quantile", "hospitalizations"],
+                        ignore_nan=True,
                     )
                 except ValueError:
                     warnings.add(
@@ -1480,7 +1488,9 @@ def generate_calibration_outputs(
                 for calibration in calibrations:
                     try:
                         quanproj_df = calibration.results.get_projection_quantiles(
-                            quantiles=flusight_quantiles, variables=["date", "quantile", transition_name]
+                            quantiles=flusight_quantiles,
+                            variables=["date", "quantile", transition_name],
+                            ignore_nan=True,
                         )
                         quanproj_df.insert(0, "primary_id", calibration.primary_id)
                         quanproj_df.insert(1, "seed", calibration.seed)

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -70,6 +70,7 @@ def _fetch_quantiles_for_location(
             cal_quant = calibration.results.get_calibration_quantiles(
                 quantiles=plots_config.quantiles.quantiles,
                 variables=["date", "data"],
+                ignore_nan=True,
             )
         except (ValueError, AttributeError, TypeError, IndexError) as e:
             logger.warning("Failed to get calibration quantiles for %s: %s", calibration.population, e)
@@ -79,6 +80,7 @@ def _fetch_quantiles_for_location(
         try:
             proj_quant = calibration.results.get_projection_quantiles(
                 quantiles=plots_config.quantiles.quantiles,
+                ignore_nan=True,
             )
         except (ValueError, AttributeError, TypeError, IndexError) as e:
             logger.warning("Failed to get projection quantiles for %s: %s", calibration.population, e)
@@ -555,6 +557,7 @@ def generate_single_quantile_plots(
                         cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
                             quantiles=[0.5],  # Only need one quantile to get dates
                             variables=["date", "data"],
+                            ignore_nan=True,
                         )
                     except (ValueError, AttributeError, TypeError, IndexError) as e:
                         logger.warning(
@@ -784,6 +787,7 @@ def generate_quantile_grid_plot(
                         cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
                             quantiles=[0.5],  # Only need one quantile to get dates
                             variables=["date", "data"],
+                            ignore_nan=True,
                         )
                     except (ValueError, AttributeError, TypeError, IndexError) as e:
                         logger.warning(


### PR DESCRIPTION
Resolves #232 . There were still some places left which did not include `ignore_nan=True` option when calling quantiles calculation function.

@rlewinter I've changed all quantile calculation calls, including the ones for FluSight hospitalizations and ED transition. Does this work fine, or could it affect outputs? I think it does not really matter since we are not submitting horizons before 0.