### PR TITLE
Bug fix: Pass dates explicitly to quantile calls

### DIFF
--- a/epymodelingsuite/dispatcher/output.py
+++ b/epymodelingsuite/dispatcher/output.py
@@ -1174,10 +1174,13 @@ def generate_calibration_outputs(
                 if hasattr(output.quantiles.calibration, "__len__"):
                     for generation in output.quantiles.calibration:
                         try:
+                            cal_trajs = calibration.results.get_selected_trajectories(generation)
+                            cal_dates = cal_trajs[0].get("date") if cal_trajs else None
                             quancal_df = calibration.results.get_calibration_quantiles(
                                 quantiles=output.quantiles.selections,
                                 generation=generation,
-                                variables=["data", "date"],
+                                dates=cal_dates,
+                                variables=["data"],
                                 ignore_nan=True,
                             )
                             quancal_df.insert(0, "primary_id", calibration.primary_id)
@@ -1191,9 +1194,12 @@ def generate_calibration_outputs(
                             )
                 else:
                     try:
+                        cal_trajs = calibration.results.get_selected_trajectories()
+                        cal_dates = cal_trajs[0].get("date") if cal_trajs else None
                         quancal_df = calibration.results.get_calibration_quantiles(
                             quantiles=output.quantiles.selections,
-                            variables=["data", "date"],
+                            dates=cal_dates,
+                            variables=["data"],
                             ignore_nan=True,
                         )
                         quancal_df.insert(0, "primary_id", calibration.primary_id)
@@ -1207,8 +1213,12 @@ def generate_calibration_outputs(
 
             # Projection quantiles
             try:
+                proj_sims = calibration.results.projections.get("baseline", [])
+                proj_dates = proj_sims[0].get("date") if proj_sims else None
                 quan_df = calibration.results.get_projection_quantiles(
-                    quantiles=output.quantiles.selections, ignore_nan=True
+                    quantiles=output.quantiles.selections,
+                    dates=proj_dates,
+                    ignore_nan=True,
                 )
             except ValueError:
                 warnings.add(
@@ -1434,9 +1444,12 @@ def generate_calibration_outputs(
             for calibration in calibrations:
                 try:
                     # FRAGILE: the name 'hospitalizations' is user-supplied in the modelset as the column to look for in the surveillance data.
+                    proj_sims = calibration.results.projections.get("baseline", [])
+                    proj_dates = proj_sims[0].get("date") if proj_sims else None
                     quanf_df = calibration.results.get_projection_quantiles(
                         quantiles=flusight_quantiles,
-                        variables=["date", "quantile", "hospitalizations"],
+                        dates=proj_dates,
+                        variables=["hospitalizations"],
                         ignore_nan=True,
                     )
                 except ValueError:
@@ -1467,9 +1480,12 @@ def generate_calibration_outputs(
             if output.flusight_format.prop_ed.strategy == "calibration_window":
                 for calibration in calibrations:
                     try:
+                        cal_trajs = calibration.results.get_selected_trajectories()
+                        cal_dates = cal_trajs[0].get("date") if cal_trajs else None
                         quancalflu_df = calibration.results.get_calibration_quantiles(
                             quantiles=flusight_quantiles,
-                            variables=["data", "date"],
+                            dates=cal_dates,
+                            variables=["data"],
                             ignore_nan=True,
                         )
                         quancalflu_df.insert(0, "primary_id", calibration.primary_id)
@@ -1487,9 +1503,12 @@ def generate_calibration_outputs(
                 transition_name = output.flusight_format.prop_ed.transition_name
                 for calibration in calibrations:
                     try:
+                        proj_sims = calibration.results.projections.get("baseline", [])
+                        proj_dates = proj_sims[0].get("date") if proj_sims else None
                         quanproj_df = calibration.results.get_projection_quantiles(
                             quantiles=flusight_quantiles,
-                            variables=["date", "quantile", transition_name],
+                            dates=proj_dates,
+                            variables=[transition_name],
                             ignore_nan=True,
                         )
                         quanproj_df.insert(0, "primary_id", calibration.primary_id)

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -67,9 +67,12 @@ def _fetch_quantiles_for_location(
     cal_quant = None
     if needs_calibration:
         try:
+            cal_trajs = calibration.results.get_selected_trajectories()
+            cal_dates = cal_trajs[0].get("date") if cal_trajs else None
             cal_quant = calibration.results.get_calibration_quantiles(
                 quantiles=plots_config.quantiles.quantiles,
-                variables=["date", "data"],
+                dates=cal_dates,
+                variables=["data"],
                 ignore_nan=True,
             )
         except (ValueError, AttributeError, TypeError, IndexError) as e:
@@ -78,8 +81,11 @@ def _fetch_quantiles_for_location(
     proj_quant = None
     if needs_projection:
         try:
+            proj_sims = calibration.results.projections.get("baseline", [])
+            proj_dates = proj_sims[0].get("date") if proj_sims else None
             proj_quant = calibration.results.get_projection_quantiles(
                 quantiles=plots_config.quantiles.quantiles,
+                dates=proj_dates,
                 ignore_nan=True,
             )
         except (ValueError, AttributeError, TypeError, IndexError) as e:
@@ -554,9 +560,12 @@ def generate_single_quantile_plots(
                 cal_quant_for_fitting = cal_quant
                 if cal_quant_for_fitting is None:
                     try:
+                        cal_trajs = calibration.results.get_selected_trajectories()
+                        cal_dates = cal_trajs[0].get("date") if cal_trajs else None
                         cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
                             quantiles=[0.5],  # Only need one quantile to get dates
-                            variables=["date", "data"],
+                            dates=cal_dates,
+                            variables=["data"],
                             ignore_nan=True,
                         )
                     except (ValueError, AttributeError, TypeError, IndexError) as e:
@@ -784,9 +793,12 @@ def generate_quantile_grid_plot(
                 cal_quant_for_fitting = location_cal_quants.get(loc)
                 if cal_quant_for_fitting is None:
                     try:
+                        cal_trajs = calibration.results.get_selected_trajectories()
+                        cal_dates = cal_trajs[0].get("date") if cal_trajs else None
                         cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
                             quantiles=[0.5],  # Only need one quantile to get dates
-                            variables=["date", "data"],
+                            dates=cal_dates,
+                            variables=["data"],
                             ignore_nan=True,
                         )
                     except (ValueError, AttributeError, TypeError, IndexError) as e:


### PR DESCRIPTION
## Summary

Adding `ignore_nan=True` to all quantile calls (#233) activated the `np.isnan` check in epydemix's `_compute_quantiles`. This crashes on the non-numeric `date` key present in trajectory dicts (`TypeError: ufunc 'isnan' not supported`). Previously with `ignore_nan=False`, the NaN check block was skipped and `np.quantile` silently handled date objects.

Even after fixing epydemix to skip non-numeric arrays ([mu373/epydemix@d61bf25](https://github.com/mu373/epydemix/commit/d61bf25)), the output `date` column contained integer indices (`np.arange`) instead of actual timestamps when `dates=None`, causing downstream failures in `format_quantiles_flusightforecast`.

## Changes made

- Extract dates from `trajectories[0]["date"]` and pass `dates=` explicitly to all quantile call sites in `output.py` and `visualization/generators.py`
- Remove `"date"` and `"quantile"` from `variables` lists (these are output metadata columns, not trajectory variables)