### PR TITLE
Fix quantile ribbon clipping in zoomed plots + visualization generators refactoring

### DIFF
--- a/epymodelingsuite/visualization/core.py
+++ b/epymodelingsuite/visualization/core.py
@@ -584,6 +584,7 @@ def plot_calibration_projection(  # noqa: PLR0913
 
 def plot_calibration_projection_sidebyside(  # noqa: PLR0913
     calibration_quantiles: pd.DataFrame | None = None,
+    calibration_quantiles_filtered: pd.DataFrame | None = None,
     projection_quantiles_full: pd.DataFrame | None = None,
     projection_quantiles_filtered: pd.DataFrame | None = None,
     surveillance_full: pd.DataFrame | None = None,
@@ -617,7 +618,9 @@ def plot_calibration_projection_sidebyside(  # noqa: PLR0913
     Parameters
     ----------
     calibration_quantiles : pd.DataFrame | None, optional
-        Pre-computed quantiles for calibration period (shown in both panels).
+        Pre-computed quantiles for calibration period (shown in full/left panel).
+    calibration_quantiles_filtered : pd.DataFrame | None, optional
+        Calibration quantiles for filtered/right panel. If None, uses calibration_quantiles.
     projection_quantiles_full : pd.DataFrame | None, optional
         Projection quantiles for left panel (full range, horizon_max only).
     projection_quantiles_filtered : pd.DataFrame | None, optional
@@ -723,8 +726,11 @@ def plot_calibration_projection_sidebyside(  # noqa: PLR0913
     )
 
     # Right panel: Filtered
+    cal_quant_for_filtered = (
+        calibration_quantiles_filtered if calibration_quantiles_filtered is not None else calibration_quantiles
+    )
     plot_calibration_projection(
-        calibration_quantiles=calibration_quantiles,
+        calibration_quantiles=cal_quant_for_filtered,
         projection_quantiles=projection_quantiles_filtered,
         value_col=value_col,
         date_col=date_col,

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -472,6 +472,7 @@ def _create_sidebyside_plot(
     plots_config: PlotsConfig,
     value_col: str,
     output_config: QuantilesOutputConfig,
+    cal_quant_filtered: pd.DataFrame | None = None,
 ) -> tuple:
     """
     Create side-by-side (full | filtered) quantile plot for a location.
@@ -481,7 +482,7 @@ def _create_sidebyside_plot(
     location : str
         Location name
     cal_quant : pd.DataFrame or None
-        Calibration quantiles (shown in both panels)
+        Calibration quantiles for full (left) panel
     proj_quant_full : pd.DataFrame or None
         Projection quantiles for left panel (full version)
     proj_quant_filtered : pd.DataFrame or None
@@ -500,6 +501,8 @@ def _create_sidebyside_plot(
         Name of value column
     output_config : QuantilesOutputConfig
         Output configuration with show flags
+    cal_quant_filtered : pd.DataFrame or None, optional
+        Calibration quantiles for filtered (right) panel. If None, uses cal_quant.
 
     Returns
     -------
@@ -512,6 +515,7 @@ def _create_sidebyside_plot(
 
     return plot_calibration_projection_sidebyside(
         calibration_quantiles=cal_quant if output_config.show_calibration else None,
+        calibration_quantiles_filtered=cal_quant_filtered if output_config.show_calibration else None,
         projection_quantiles_full=proj_quant_full if output_config.show_projection else None,
         projection_quantiles_filtered=proj_quant_filtered if output_config.show_projection else None,
         surveillance_full=df_surv_full if output_config.show_surveillance else None,
@@ -712,6 +716,26 @@ def generate_single_quantile_plots(
                         elif output_config.surveillance_points is not None:
                             surv_to_use = surv_to_use.sort_values("date").tail(output_config.surveillance_points)
 
+                    # For filtered plots, clip projection and calibration quantiles to
+                    # the visible surveillance start so the ribbons match the zoomed view
+                    cal_to_use = cal_quant
+                    if output_config.type == QuantilesOutputTypeEnum.FILTERED:
+                        effective_surv_start = None
+                        if surv_to_use is not None and not surv_to_use.empty:
+                            effective_surv_start = pd.to_datetime(surv_to_use["date"]).dt.date.min()
+
+                        if effective_surv_start is not None:
+                            if proj_to_use is not None:
+                                proj_dates = pd.to_datetime(proj_to_use["date"]).dt.date
+                                proj_to_use = proj_to_use[proj_dates >= effective_surv_start]
+                                if proj_to_use.empty:
+                                    proj_to_use = None
+                            if cal_to_use is not None:
+                                cal_dates = pd.to_datetime(cal_to_use["date"]).dt.date
+                                cal_to_use = cal_to_use[cal_dates >= effective_surv_start]
+                                if cal_to_use.empty:
+                                    cal_to_use = None
+
                     # Apply per-output horizon_max if specified (overrides base config)
                     if proj_to_use is not None and output_config.horizon_max is not None:
                         proj_dates = pd.to_datetime(proj_to_use["date"]).dt.date
@@ -722,7 +746,7 @@ def generate_single_quantile_plots(
                     if output_config.type == QuantilesOutputTypeEnum.FILTERED:
                         fig, ax = _create_filtered_plot(
                             location,
-                            cal_quant,
+                            cal_to_use,
                             proj_to_use,
                             surv_to_use,
                             fitting_window_start,
@@ -744,11 +768,27 @@ def generate_single_quantile_plots(
                             output_config,
                         )
                     elif output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
+                        # Clip calibration and projection quantiles for the filtered panel
+                        cal_quant_for_filtered = cal_quant
+                        proj_quant_for_filtered = proj_quant_filtered
+                        if df_surv_filtered is not None and not df_surv_filtered.empty:
+                            sbs_surv_start = pd.to_datetime(df_surv_filtered["date"]).dt.date.min()
+                            if cal_quant_for_filtered is not None:
+                                cal_dates = pd.to_datetime(cal_quant_for_filtered["date"]).dt.date
+                                cal_quant_for_filtered = cal_quant_for_filtered[cal_dates >= sbs_surv_start]
+                                if cal_quant_for_filtered.empty:
+                                    cal_quant_for_filtered = None
+                            if proj_quant_for_filtered is not None:
+                                proj_dates = pd.to_datetime(proj_quant_for_filtered["date"]).dt.date
+                                proj_quant_for_filtered = proj_quant_for_filtered[proj_dates >= sbs_surv_start]
+                                if proj_quant_for_filtered.empty:
+                                    proj_quant_for_filtered = None
+
                         fig, (ax_full, ax_filtered) = _create_sidebyside_plot(
                             location,
                             cal_quant,
                             proj_quant_full,
-                            proj_quant_filtered,
+                            proj_quant_for_filtered,
                             df_surv_full,
                             df_surv_filtered,
                             fitting_window_start,
@@ -756,6 +796,7 @@ def generate_single_quantile_plots(
                             plots_config,
                             value_col,
                             output_config,
+                            cal_quant_filtered=cal_quant_for_filtered,
                         )
                     else:
                         logger.warning("Unknown output type %s for %s", output_config.type, location)
@@ -1031,6 +1072,43 @@ def generate_quantile_grid_plot(
                         )
                     surv_data_to_use = surv_data_filtered_by_output
 
+            # For filtered plots, clip projection and calibration quantiles to
+            # the visible surveillance start so the ribbons match the zoomed view
+            cal_quants_to_use = location_cal_quants
+            if output_type_name == "filtered" and surv_data_to_use:
+                cal_quants_clipped = {}
+                proj_quants_clipped = {}
+                for loc in set(list(cal_quants_to_use or []) + list(proj_quants_to_use or [])):
+                    surv_df = surv_data_to_use.get(loc)
+                    effective_surv_start = None
+                    if surv_df is not None and not surv_df.empty:
+                        effective_surv_start = pd.to_datetime(surv_df["date"]).dt.date.min()
+
+                    if loc in (cal_quants_to_use or {}):
+                        if effective_surv_start is not None:
+                            cal_df = cal_quants_to_use[loc]
+                            cal_dates = pd.to_datetime(cal_df["date"]).dt.date
+                            clipped = cal_df[cal_dates >= effective_surv_start]
+                            if not clipped.empty:
+                                cal_quants_clipped[loc] = clipped
+                        else:
+                            cal_quants_clipped[loc] = cal_quants_to_use[loc]
+
+                    if loc in (proj_quants_to_use or {}):
+                        if effective_surv_start is not None:
+                            proj_df = proj_quants_to_use[loc]
+                            proj_dates = pd.to_datetime(proj_df["date"]).dt.date
+                            clipped = proj_df[proj_dates >= effective_surv_start]
+                            if not clipped.empty:
+                                proj_quants_clipped[loc] = clipped
+                        else:
+                            proj_quants_clipped[loc] = proj_quants_to_use[loc]
+
+                if cal_quants_to_use:
+                    cal_quants_to_use = cal_quants_clipped
+                if proj_quants_to_use:
+                    proj_quants_to_use = proj_quants_clipped
+
             # Apply per-output horizon_max if specified (overrides base config)
             if proj_quants_to_use and output_config.horizon_max is not None:
                 proj_quants_horizon_filtered = {}
@@ -1047,7 +1125,7 @@ def generate_quantile_grid_plot(
                 try:
                     fig, axes = plot_calibration_projection_grid(
                         location_calibration_quantiles=(
-                            location_cal_quants if output_config.show_calibration and location_cal_quants else None
+                            cal_quants_to_use if output_config.show_calibration and cal_quants_to_use else None
                         ),
                         location_projection_quantiles=(
                             proj_quants_to_use if output_config.show_projection and proj_quants_to_use else None
@@ -1243,6 +1321,22 @@ def generate_quantile_grid_plot(
                                         surv_filtered = surv_filtered.sort_values("date").tail(
                                             output_config.filtered_panel.surveillance_points
                                         )
+
+                            # Clip filtered panel quantiles to visible surveillance start
+                            cal_quant_filtered = cal_quant
+                            if surv_filtered is not None and not surv_filtered.empty:
+                                effective_surv_start = pd.to_datetime(surv_filtered["date"]).dt.date.min()
+                                if cal_quant_filtered is not None:
+                                    cal_dates = pd.to_datetime(cal_quant_filtered["date"]).dt.date
+                                    cal_quant_filtered = cal_quant_filtered[cal_dates >= effective_surv_start]
+                                    if cal_quant_filtered.empty:
+                                        cal_quant_filtered = None
+                                if proj_quant_filtered is not None:
+                                    proj_dates = pd.to_datetime(proj_quant_filtered["date"]).dt.date
+                                    proj_quant_filtered = proj_quant_filtered[proj_dates >= effective_surv_start]
+                                    if proj_quant_filtered.empty:
+                                        proj_quant_filtered = None
+
                             fitting_window_start = (
                                 location_fitting_window_starts.get(location)
                                 if output_config.show_fitting_window_line and location_fitting_window_starts
@@ -1266,6 +1360,7 @@ def generate_quantile_grid_plot(
                             sbs_title_suffix = location_notes.get(location, ("", ""))[0]
                             plot_calibration_projection_sidebyside(
                                 calibration_quantiles=cal_quant,
+                                calibration_quantiles_filtered=cal_quant_filtered,
                                 projection_quantiles_full=proj_quant_full,
                                 projection_quantiles_filtered=proj_quant_filtered,
                                 surveillance_full=surv_full,

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -355,7 +355,22 @@ def _clip_to_surveillance_start(
     df: pd.DataFrame | None,
     surv: pd.DataFrame | None,
 ) -> pd.DataFrame | None:
-    """Clip df to start at the earliest date in surv. Returns None if empty or inputs are None."""
+    """
+    Clip a dataframe to start at the earliest date in surveillance data. Used to align calibration/projection quantile ribbons with the visible surveillance range.
+
+    Parameters
+    ----------
+    df : pd.DataFrame or None
+        DataFrame with a "date" column (e.g. calibration or projection quantiles).
+    surv : pd.DataFrame or None
+        Surveillance DataFrame with a "date" column whose minimum date defines the clip boundary.
+
+    Returns
+    -------
+    pd.DataFrame or None
+        Rows of ``df`` where date >= earliest surveillance date, or None if the result is empty.
+        Returns ``df`` unchanged when ``surv`` is None or empty.
+    """
     if df is None or surv is None or surv.empty:
         return df
     start = pd.to_datetime(surv["date"]).dt.date.min()
@@ -369,7 +384,25 @@ def _apply_surveillance_filter(
     surveillance_start_date: str | None = None,
     surveillance_points: int | None = None,
 ) -> pd.DataFrame | None:
-    """Filter surveillance by start date (priority) or last N points."""
+    """
+    Filter surveillance data by a start date or by keeping the last N points.
+
+    When both parameters are provided, ``surveillance_start_date`` takes precedence.
+
+    Parameters
+    ----------
+    surv : pd.DataFrame or None
+        Surveillance DataFrame with a "date" column.
+    surveillance_start_date : str or None
+        If given, keep only rows with date >= this value (parsed via ``pd.to_datetime``).
+    surveillance_points : int or None
+        If given (and ``surveillance_start_date`` is None), keep only the last N rows by date.
+
+    Returns
+    -------
+    pd.DataFrame or None
+        Filtered surveillance data, or the input unchanged if no filter applies.
+    """
     if surv is None or surv.empty:
         return surv
     if surveillance_start_date is not None:
@@ -386,7 +419,26 @@ def _apply_horizon_filter(
     horizon_max: int | None,
     reference_date: date,
 ) -> pd.DataFrame | None:
-    """Clip projection quantiles to reference_date + horizon_max weeks."""
+    """
+    Clip projection quantiles to a maximum forecast horizon.
+
+    Keeps only rows whose date is at most ``reference_date + horizon_max`` weeks.
+    Returns a copy to avoid mutating the caller's DataFrame.
+
+    Parameters
+    ----------
+    proj : pd.DataFrame or None
+        Projection quantiles DataFrame with a "date" column.
+    horizon_max : int or None
+        Maximum number of weeks past ``reference_date`` to keep. If None, no clipping is applied.
+    reference_date : date
+        The reference date from which the horizon is measured.
+
+    Returns
+    -------
+    pd.DataFrame or None
+        Clipped projection data, or ``proj`` unchanged when ``horizon_max`` is None.
+    """
     if proj is None or horizon_max is None:
         return proj
     proj = proj.copy()
@@ -399,7 +451,24 @@ def _load_surveillance_sources(
     surveillance_sources: dict[str, ObservedValuesConfig] | None,
     outputs: list[QuantilesOutputConfig],
 ) -> dict[str, dict[str, Any]]:
-    """Load surveillance CSVs if any output needs surveillance. Returns {name: {"data": df, "config": config}}."""
+    """
+    Load surveillance CSV files for all configured sources.
+
+    Skips loading entirely if no output requires surveillance data or if no sources are configured.
+
+    Parameters
+    ----------
+    surveillance_sources : dict[str, ObservedValuesConfig] or None
+        Mapping of source name to its configuration (including ``data_path``).
+    outputs : list[QuantilesOutputConfig]
+        Output configurations; loading is skipped if none have ``show_surveillance`` enabled.
+
+    Returns
+    -------
+    dict[str, dict[str, Any]]
+        Mapping of source name to ``{"data": pd.DataFrame, "config": ObservedValuesConfig}``.
+        Empty dict if no sources are needed or available.
+    """
     if not any(o.show_surveillance for o in outputs) or not surveillance_sources:
         return {}
     result: dict[str, dict[str, Any]] = {}
@@ -415,7 +484,23 @@ def _compute_fitting_window(
     calibration: CalibrationOutput,
     cal_quant: pd.DataFrame | None,
 ) -> tuple[date | None, date | None]:
-    """Compute fitting window start/end from calibration quantiles, with fallback fetch."""
+    """
+    Compute the fitting window date range from calibration quantiles.
+
+    Uses the provided ``cal_quant`` if available; otherwise falls back to fetching a minimal set of calibration quantiles (median only) from the calibration results.
+
+    Parameters
+    ----------
+    calibration : CalibrationOutput
+        Calibration output for one location, used as fallback source for quantile data.
+    cal_quant : pd.DataFrame or None
+        Pre-fetched calibration quantiles. If None, the function attempts to fetch them.
+
+    Returns
+    -------
+    tuple[date or None, date or None]
+        (start, end) of the fitting window, or (None, None) if quantiles are unavailable.
+    """
     cal_quant_for_fitting = cal_quant
     if cal_quant_for_fitting is None:
         try:
@@ -445,7 +530,23 @@ def _package_figure_outputs(
     name: str,
     plots_config: PlotsConfig,
 ) -> list[OutputObject]:
-    """Convert figure to OutputObjects for all configured output types."""
+    """
+    Convert a matplotlib figure to OutputObject instances for each configured format.
+
+    Parameters
+    ----------
+    fig : plt.Figure
+        The matplotlib figure to serialize.
+    name : str
+        Base name for the output (used in filenames).
+    plots_config : PlotsConfig
+        Configuration providing ``figure_output_types`` (e.g. png, svg) and ``dpi``.
+
+    Returns
+    -------
+    list[OutputObject]
+        One OutputObject per configured figure output type.
+    """
     return [
         figure_to_output_object(fig, name, output_type, plots_config.dpi)
         for output_type in plots_config.figure_output_types

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -383,6 +383,7 @@ def _clip_surveillance(
     *,
     surveillance_start_date: str | None = None,
     surveillance_points: int | None = None,
+    reference_date: date | None = None,
 ) -> pd.DataFrame | None:
     """
     Filter surveillance data by a start date or by keeping the last N points.
@@ -396,7 +397,11 @@ def _clip_surveillance(
     surveillance_start_date : str or None
         If given, keep only rows with date >= this value (parsed via ``pd.to_datetime``).
     surveillance_points : int or None
-        If given (and ``surveillance_start_date`` is None), keep only the last N rows by date.
+        If given (and ``surveillance_start_date`` is None), keep the last N rows
+        *before* ``reference_date``, plus all rows after it.
+    reference_date : date or None
+        The reference date used to split before/after when ``surveillance_points``
+        is specified. Required when ``surveillance_points`` is not None.
 
     Returns
     -------
@@ -410,7 +415,13 @@ def _clip_surveillance(
         dates = pd.to_datetime(surv["date"]).dt.date
         return surv[dates >= start]
     if surveillance_points is not None:
-        return surv.sort_values("date").tail(surveillance_points)
+        surv = surv.sort_values("date")
+        dates = pd.to_datetime(surv["date"]).dt.date
+        if reference_date is not None:
+            before = surv[dates <= reference_date].tail(surveillance_points)
+            after = surv[dates > reference_date]
+            return pd.concat([before, after])
+        return surv.tail(surveillance_points)
     return surv
 
 
@@ -828,6 +839,7 @@ def generate_single_quantile_plots(
                         surv_to_use,
                         surveillance_start_date=output_config.surveillance_start_date,
                         surveillance_points=output_config.surveillance_points,
+                        reference_date=plots_config.reference_date,
                     )
 
                     # For filtered plots, clip projection and calibration quantiles to
@@ -838,9 +850,7 @@ def generate_single_quantile_plots(
                         cal_to_use = _clip_to_surveillance_start(cal_to_use, surv_to_use)
 
                     # Apply per-output horizon_max if specified (overrides base config)
-                    proj_to_use = _clip_to_horizon(
-                        proj_to_use, output_config.horizon_max, plots_config.reference_date
-                    )
+                    proj_to_use = _clip_to_horizon(proj_to_use, output_config.horizon_max, plots_config.reference_date)
 
                     # Create the plot
                     if output_config.type == QuantilesOutputTypeEnum.FILTERED:
@@ -1116,6 +1126,7 @@ def generate_quantile_grid_plot(
                         surv_df,
                         surveillance_start_date=output_config.surveillance_start_date,
                         surveillance_points=output_config.surveillance_points,
+                        reference_date=plots_config.reference_date,
                     )
                     for loc, surv_df in surv_data_to_use.items()
                 }
@@ -1320,6 +1331,7 @@ def generate_quantile_grid_plot(
                                         surv_full,
                                         surveillance_start_date=output_config.full_panel.surveillance_start_date,
                                         surveillance_points=output_config.full_panel.surveillance_points,
+                                        reference_date=plots_config.reference_date,
                                     )
 
                             surv_filtered = None
@@ -1334,6 +1346,7 @@ def generate_quantile_grid_plot(
                                         surv_filtered,
                                         surveillance_start_date=output_config.filtered_panel.surveillance_start_date,
                                         surveillance_points=output_config.filtered_panel.surveillance_points,
+                                        reference_date=plots_config.reference_date,
                                     )
 
                             # Clip filtered panel quantiles to visible surveillance start

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -380,6 +380,20 @@ def _apply_surveillance_filter(
     return surv
 
 
+def _apply_horizon_filter(
+    proj: pd.DataFrame | None,
+    horizon_max: int | None,
+    reference_date: date,
+) -> pd.DataFrame | None:
+    """Clip projection quantiles to reference_date + horizon_max weeks."""
+    if proj is None or horizon_max is None:
+        return proj
+    proj = proj.copy()
+    dates = pd.to_datetime(proj["date"]).dt.date
+    end = reference_date + timedelta(weeks=horizon_max)
+    return proj[dates.values <= end]
+
+
 def _create_quantile_plot(
     location: str,
     cal_quant: pd.DataFrame | None,
@@ -696,10 +710,9 @@ def generate_single_quantile_plots(
                         cal_to_use = _clip_to_surveillance_start(cal_to_use, surv_to_use)
 
                     # Apply per-output horizon_max if specified (overrides base config)
-                    if proj_to_use is not None and output_config.horizon_max is not None:
-                        proj_dates = pd.to_datetime(proj_to_use["date"]).dt.date
-                        horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
-                        proj_to_use = proj_to_use[proj_dates.values <= horizon_end]
+                    proj_to_use = _apply_horizon_filter(
+                        proj_to_use, output_config.horizon_max, plots_config.reference_date
+                    )
 
                     # Create the plot
                     if output_config.type == QuantilesOutputTypeEnum.FILTERED:
@@ -1034,13 +1047,10 @@ def generate_quantile_grid_plot(
 
             # Apply per-output horizon_max if specified (overrides base config)
             if proj_quants_to_use and output_config.horizon_max is not None:
-                proj_quants_horizon_filtered = {}
-                for loc, proj_df in proj_quants_to_use.items():
-                    proj_df_copy = proj_df.copy()
-                    proj_dates = pd.to_datetime(proj_df_copy["date"]).dt.date
-                    horizon_end = plots_config.reference_date + timedelta(weeks=output_config.horizon_max)
-                    proj_quants_horizon_filtered[loc] = proj_df_copy[proj_dates.values <= horizon_end]
-                proj_quants_to_use = proj_quants_horizon_filtered
+                proj_quants_to_use = {
+                    loc: _apply_horizon_filter(df, output_config.horizon_max, plots_config.reference_date)
+                    for loc, df in proj_quants_to_use.items()
+                }
 
             # Generate grid plot based on output type
             if output_type_name in ["filtered", "full"]:

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -362,6 +362,24 @@ def _clip_to_surveillance_start(
     return clipped if not clipped.empty else None
 
 
+def _apply_surveillance_filter(
+    surv: pd.DataFrame | None,
+    *,
+    surveillance_start_date: str | None = None,
+    surveillance_points: int | None = None,
+) -> pd.DataFrame | None:
+    """Filter surveillance by start date (priority) or last N points."""
+    if surv is None or surv.empty:
+        return surv
+    if surveillance_start_date is not None:
+        start = pd.to_datetime(surveillance_start_date).date()
+        dates = pd.to_datetime(surv["date"]).dt.date
+        return surv[dates >= start]
+    if surveillance_points is not None:
+        return surv.sort_values("date").tail(surveillance_points)
+    return surv
+
+
 def _create_quantile_plot(
     location: str,
     cal_quant: pd.DataFrame | None,
@@ -664,14 +682,11 @@ def generate_single_quantile_plots(
                         continue
 
                     # Apply per-output surveillance filtering if needed (for filtered/full types)
-                    if surv_to_use is not None:
-                        # Date-based filtering takes precedence over points-based filtering
-                        if output_config.surveillance_start_date is not None:
-                            start_date = pd.to_datetime(output_config.surveillance_start_date).date()
-                            surv_dates = pd.to_datetime(surv_to_use["date"]).dt.date
-                            surv_to_use = surv_to_use[surv_dates >= start_date]
-                        elif output_config.surveillance_points is not None:
-                            surv_to_use = surv_to_use.sort_values("date").tail(output_config.surveillance_points)
+                    surv_to_use = _apply_surveillance_filter(
+                        surv_to_use,
+                        surveillance_start_date=output_config.surveillance_start_date,
+                        surveillance_points=output_config.surveillance_points,
+                    )
 
                     # For filtered plots, clip projection and calibration quantiles to
                     # the visible surveillance start so the ribbons match the zoomed view
@@ -987,22 +1002,14 @@ def generate_quantile_grid_plot(
 
             # Apply per-output surveillance filtering if needed
             if surv_data_to_use:
-                # Date-based filtering takes precedence over points-based filtering
-                if output_config.surveillance_start_date is not None:
-                    surv_data_filtered_by_output = {}
-                    start_date = pd.to_datetime(output_config.surveillance_start_date).date()
-                    for loc, surv_df in surv_data_to_use.items():
-                        surv_df_copy = surv_df.copy()
-                        surv_dates = pd.to_datetime(surv_df_copy["date"]).dt.date
-                        surv_data_filtered_by_output[loc] = surv_df_copy[surv_dates >= start_date]
-                    surv_data_to_use = surv_data_filtered_by_output
-                elif output_config.surveillance_points is not None:
-                    surv_data_filtered_by_output = {}
-                    for loc, surv_df in surv_data_to_use.items():
-                        surv_data_filtered_by_output[loc] = surv_df.sort_values("date").tail(
-                            output_config.surveillance_points
-                        )
-                    surv_data_to_use = surv_data_filtered_by_output
+                surv_data_to_use = {
+                    loc: _apply_surveillance_filter(
+                        surv_df,
+                        surveillance_start_date=output_config.surveillance_start_date,
+                        surveillance_points=output_config.surveillance_points,
+                    )
+                    for loc, surv_df in surv_data_to_use.items()
+                }
 
             # For filtered plots, clip projection and calibration quantiles to
             # the visible surveillance start so the ribbons match the zoomed view
@@ -1208,16 +1215,11 @@ def generate_quantile_grid_plot(
                             ):
                                 surv_full = location_surveillance_full_sbs[location].copy()
                                 if output_config.full_panel:
-                                    if output_config.full_panel.surveillance_start_date is not None:
-                                        start_date = pd.to_datetime(
-                                            output_config.full_panel.surveillance_start_date
-                                        ).date()
-                                        surv_dates = pd.to_datetime(surv_full["date"]).dt.date
-                                        surv_full = surv_full[surv_dates >= start_date]
-                                    elif output_config.full_panel.surveillance_points is not None:
-                                        surv_full = surv_full.sort_values("date").tail(
-                                            output_config.full_panel.surveillance_points
-                                        )
+                                    surv_full = _apply_surveillance_filter(
+                                        surv_full,
+                                        surveillance_start_date=output_config.full_panel.surveillance_start_date,
+                                        surveillance_points=output_config.full_panel.surveillance_points,
+                                    )
 
                             surv_filtered = None
                             if (
@@ -1227,16 +1229,11 @@ def generate_quantile_grid_plot(
                             ):
                                 surv_filtered = location_surveillance_filtered_sbs[location].copy()
                                 if output_config.filtered_panel:
-                                    if output_config.filtered_panel.surveillance_start_date is not None:
-                                        start_date = pd.to_datetime(
-                                            output_config.filtered_panel.surveillance_start_date
-                                        ).date()
-                                        surv_dates = pd.to_datetime(surv_filtered["date"]).dt.date
-                                        surv_filtered = surv_filtered[surv_dates >= start_date]
-                                    elif output_config.filtered_panel.surveillance_points is not None:
-                                        surv_filtered = surv_filtered.sort_values("date").tail(
-                                            output_config.filtered_panel.surveillance_points
-                                        )
+                                    surv_filtered = _apply_surveillance_filter(
+                                        surv_filtered,
+                                        surveillance_start_date=output_config.filtered_panel.surveillance_start_date,
+                                        surveillance_points=output_config.filtered_panel.surveillance_points,
+                                    )
 
                             # Clip filtered panel quantiles to visible surveillance start
                             cal_quant_filtered = _clip_to_surveillance_start(cal_quant, surv_filtered)

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -350,19 +350,19 @@ def _rename_value_column(df: pd.DataFrame | None, old_name: str) -> pd.DataFrame
     raise ValueError(msg)
 
 
-def _create_filtered_plot(
+def _create_quantile_plot(
     location: str,
     cal_quant: pd.DataFrame | None,
     proj_quant: pd.DataFrame | None,
     df_surv: pd.DataFrame | None,
-    fitting_window_start: pd.Timestamp | None,
-    fitting_window_end: pd.Timestamp | None,
+    fitting_window_start: date | None,
+    fitting_window_end: date | None,
     plots_config: PlotsConfig,
     value_col: str,
     output_config: QuantilesOutputConfig,
 ) -> tuple:
     """
-    Create filtered quantile plot for a location.
+    Create a quantile plot (filtered or full) for a location.
 
     Parameters
     ----------
@@ -371,67 +371,12 @@ def _create_filtered_plot(
     cal_quant : pd.DataFrame or None
         Calibration quantiles
     proj_quant : pd.DataFrame or None
-        Projection quantiles (filtered version)
+        Projection quantiles
     df_surv : pd.DataFrame or None
-        Surveillance data (filtered version)
-    fitting_window_start : pd.Timestamp or None
+        Surveillance data
+    fitting_window_start : date or None
         Start of fitting window
-    fitting_window_end : pd.Timestamp or None
-        End of fitting window
-    plots_config : PlotsConfig
-        Plot configuration
-    value_col : str
-        Name of value column
-    output_config : QuantilesOutputConfig
-        Output configuration with show flags
-
-    Returns
-    -------
-    tuple
-        (fig, ax) matplotlib figure and axes
-    """
-    return plot_calibration_projection(
-        calibration_quantiles=cal_quant if output_config.show_calibration else None,
-        projection_quantiles=proj_quant if output_config.show_projection else None,
-        value_col=value_col,
-        calibration_color=plots_config.quantiles.calibration.color,
-        projection_color=plots_config.quantiles.projection.color,
-        df_surveillance=df_surv if output_config.show_surveillance else None,
-        fitting_window_start=fitting_window_start if output_config.show_fitting_window_line else None,
-        fitting_window_end=fitting_window_end if output_config.show_fitting_window_line else None,
-        title=format_location_name(location),
-        xlabel_interval=output_config.xlabel_interval,
-        ylabel=plots_config.quantiles.ylabel,
-    )
-
-
-def _create_full_plot(
-    location: str,
-    cal_quant: pd.DataFrame | None,
-    proj_quant: pd.DataFrame | None,
-    df_surv: pd.DataFrame | None,
-    fitting_window_start: pd.Timestamp | None,
-    fitting_window_end: pd.Timestamp | None,
-    plots_config: PlotsConfig,
-    value_col: str,
-    output_config: QuantilesOutputConfig,
-) -> tuple:
-    """
-    Create full quantile plot for a location.
-
-    Parameters
-    ----------
-    location : str
-        Location name
-    cal_quant : pd.DataFrame or None
-        Calibration quantiles
-    proj_quant : pd.DataFrame or None
-        Projection quantiles (full version)
-    df_surv : pd.DataFrame or None
-        Surveillance data (full version)
-    fitting_window_start : pd.Timestamp or None
-        Start of fitting window
-    fitting_window_end : pd.Timestamp or None
+    fitting_window_end : date or None
         End of fitting window
     plots_config : PlotsConfig
         Plot configuration
@@ -467,8 +412,8 @@ def _create_sidebyside_plot(
     proj_quant_filtered: pd.DataFrame | None,
     df_surv_full: pd.DataFrame | None,
     df_surv_filtered: pd.DataFrame | None,
-    fitting_window_start: pd.Timestamp | None,
-    fitting_window_end: pd.Timestamp | None,
+    fitting_window_start: date | None,
+    fitting_window_end: date | None,
     plots_config: PlotsConfig,
     value_col: str,
     output_config: QuantilesOutputConfig,
@@ -491,9 +436,9 @@ def _create_sidebyside_plot(
         Surveillance data for left panel (full version)
     df_surv_filtered : pd.DataFrame or None
         Surveillance data for right panel (filtered version)
-    fitting_window_start : pd.Timestamp or None
+    fitting_window_start : date or None
         Start of fitting window
-    fitting_window_end : pd.Timestamp or None
+    fitting_window_end : date or None
         End of fitting window
     plots_config : PlotsConfig
         Plot configuration
@@ -744,7 +689,7 @@ def generate_single_quantile_plots(
 
                     # Create the plot
                     if output_config.type == QuantilesOutputTypeEnum.FILTERED:
-                        fig, ax = _create_filtered_plot(
+                        fig, ax = _create_quantile_plot(
                             location,
                             cal_to_use,
                             proj_to_use,
@@ -756,7 +701,7 @@ def generate_single_quantile_plots(
                             output_config,
                         )
                     elif output_config.type == QuantilesOutputTypeEnum.FULL:
-                        fig, ax = _create_full_plot(
+                        fig, ax = _create_quantile_plot(
                             location,
                             cal_quant,
                             proj_to_use,

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -411,6 +411,35 @@ def _load_surveillance_sources(
     return result
 
 
+def _compute_fitting_window(
+    calibration: CalibrationOutput,
+    cal_quant: pd.DataFrame | None,
+) -> tuple[date | None, date | None]:
+    """Compute fitting window start/end from calibration quantiles, with fallback fetch."""
+    cal_quant_for_fitting = cal_quant
+    if cal_quant_for_fitting is None:
+        try:
+            cal_trajs = calibration.results.get_selected_trajectories()
+            cal_dates = cal_trajs[0].get("date") if cal_trajs else None
+            cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
+                quantiles=[0.5],
+                dates=cal_dates,
+                variables=["data"],
+                ignore_nan=True,
+            )
+        except (ValueError, AttributeError, TypeError, IndexError) as e:
+            logger.warning(
+                "Failed to get calibration quantiles for fitting window for %s: %s",
+                calibration.population,
+                e,
+            )
+
+    if cal_quant_for_fitting is not None and "date" in cal_quant_for_fitting.columns:
+        dates = pd.to_datetime(cal_quant_for_fitting["date"]).dt.date
+        return dates.min(), dates.max()
+    return None, None
+
+
 def _create_quantile_plot(
     location: str,
     cal_quant: pd.DataFrame | None,
@@ -632,28 +661,7 @@ def generate_single_quantile_plots(
             fitting_window_start = None
             fitting_window_end = None
             if needs_fitting_window:
-                cal_quant_for_fitting = cal_quant
-                if cal_quant_for_fitting is None:
-                    try:
-                        cal_trajs = calibration.results.get_selected_trajectories()
-                        cal_dates = cal_trajs[0].get("date") if cal_trajs else None
-                        cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
-                            quantiles=[0.5],  # Only need one quantile to get dates
-                            dates=cal_dates,
-                            variables=["data"],
-                            ignore_nan=True,
-                        )
-                    except (ValueError, AttributeError, TypeError, IndexError) as e:
-                        logger.warning(
-                            "Failed to get calibration quantiles for fitting window for %s: %s",
-                            location,
-                            e,
-                        )
-
-                if cal_quant_for_fitting is not None and "date" in cal_quant_for_fitting.columns:
-                    dates = pd.to_datetime(cal_quant_for_fitting["date"]).dt.date
-                    fitting_window_start = dates.min()
-                    fitting_window_end = dates.max()
+                fitting_window_start, fitting_window_end = _compute_fitting_window(calibration, cal_quant)
 
             # TODO: Determine which surveillance source to use (logic will be added with per-output processing)
             # For now, use first available source if any
@@ -881,29 +889,10 @@ def generate_quantile_grid_plot(
 
             # Calculate fitting window start and end from calibration quantiles
             if needs_fitting_window:
-                # Fetch calibration quantiles for fitting window calculation even if not displaying them
-                cal_quant_for_fitting = location_cal_quants.get(loc)
-                if cal_quant_for_fitting is None:
-                    try:
-                        cal_trajs = calibration.results.get_selected_trajectories()
-                        cal_dates = cal_trajs[0].get("date") if cal_trajs else None
-                        cal_quant_for_fitting = calibration.results.get_calibration_quantiles(
-                            quantiles=[0.5],  # Only need one quantile to get dates
-                            dates=cal_dates,
-                            variables=["data"],
-                            ignore_nan=True,
-                        )
-                    except (ValueError, AttributeError, TypeError, IndexError) as e:
-                        logger.warning(
-                            "Failed to get calibration quantiles for fitting window for %s: %s",
-                            loc,
-                            e,
-                        )
-
-                if cal_quant_for_fitting is not None and "date" in cal_quant_for_fitting.columns:
-                    dates = pd.to_datetime(cal_quant_for_fitting["date"]).dt.date
-                    location_fitting_window_starts[loc] = dates.min()
-                    location_fitting_window_ends[loc] = dates.max()
+                fw_start, fw_end = _compute_fitting_window(calibration, location_cal_quants.get(loc))
+                if fw_start is not None:
+                    location_fitting_window_starts[loc] = fw_start
+                    location_fitting_window_ends[loc] = fw_end
         except Exception as e:
             logger.warning(
                 "Failed to process location %s for grid quantile plots: %s",

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -440,6 +440,18 @@ def _compute_fitting_window(
     return None, None
 
 
+def _package_figure_outputs(
+    fig: plt.Figure,
+    name: str,
+    plots_config: PlotsConfig,
+) -> list[OutputObject]:
+    """Convert figure to OutputObjects for all configured output types."""
+    return [
+        figure_to_output_object(fig, name, output_type, plots_config.dpi)
+        for output_type in plots_config.figure_output_types
+    ]
+
+
 def _create_quantile_plot(
     location: str,
     cal_quant: pd.DataFrame | None,
@@ -790,12 +802,7 @@ def generate_single_quantile_plots(
                         _add_footnote(fig, footnote)
 
                     # Package output
-                    output_objs = []
-                    for figure_output_type in plots_config.figure_output_types:
-                        output_objs.append(
-                            figure_to_output_object(fig, output_name, figure_output_type, plots_config.dpi)
-                        )
-                    out_dict[output_name] = output_objs
+                    out_dict[output_name] = _package_figure_outputs(fig, output_name, plots_config)
                     plt.close(fig)
                 except Exception as e:
                     logger.warning(
@@ -889,10 +896,12 @@ def generate_quantile_grid_plot(
 
             # Calculate fitting window start and end from calibration quantiles
             if needs_fitting_window:
-                fw_start, fw_end = _compute_fitting_window(calibration, location_cal_quants.get(loc))
-                if fw_start is not None:
-                    location_fitting_window_starts[loc] = fw_start
-                    location_fitting_window_ends[loc] = fw_end
+                fitting_window_start, fitting_window_end = _compute_fitting_window(
+                    calibration, location_cal_quants.get(loc)
+                )
+                if fitting_window_start is not None:
+                    location_fitting_window_starts[loc] = fitting_window_start
+                    location_fitting_window_ends[loc] = fitting_window_end
         except Exception as e:
             logger.warning(
                 "Failed to process location %s for grid quantile plots: %s",
@@ -1082,14 +1091,9 @@ def generate_quantile_grid_plot(
                         _add_footnote(fig, "; ".join(sorted(grid_footnotes)))
 
                     # Package output
-                    output_objs = []
-                    for fig_output_type in plots_config.figure_output_types:
-                        output_objs.append(
-                            figure_to_output_object(
-                                fig, f"quantiles_grid_{output_type_name}", fig_output_type, plots_config.dpi
-                            )
-                        )
-                    out_dict[f"quantiles_grid_{output_type_name}"] = output_objs
+                    out_dict[f"quantiles_grid_{output_type_name}"] = _package_figure_outputs(
+                        fig, f"quantiles_grid_{output_type_name}", plots_config
+                    )
                     plt.close(fig)
                 except Exception as e:
                     logger.warning("Failed to create %s quantile grid plot: %s", output_type_name, e, exc_info=True)
@@ -1304,14 +1308,9 @@ def generate_quantile_grid_plot(
                             _add_footnote(fig, "; ".join(sorted(sbs_footnotes)))
 
                         # Package output
-                        output_objs = []
-                        for fig_output_type in plots_config.figure_output_types:
-                            output_objs.append(
-                                figure_to_output_object(
-                                    fig, "quantiles_grid_sidebyside", fig_output_type, plots_config.dpi
-                                )
-                            )
-                        out_dict["quantiles_grid_sidebyside"] = output_objs
+                        out_dict["quantiles_grid_sidebyside"] = _package_figure_outputs(
+                            fig, "quantiles_grid_sidebyside", plots_config
+                        )
                         plt.close(fig)
                 except Exception as e:
                     logger.warning("Failed to create sidebyside quantile grid plot: %s", e, exc_info=True)
@@ -1416,10 +1415,7 @@ def generate_single_location_posterior_plots(
                 _add_footnote(fig, footnote)
 
             # Package output
-            output_objs = []
-            for output_type in plots_config.figure_output_types:
-                output_objs.append(figure_to_output_object(fig, f"posterior_{location}", output_type, plots_config.dpi))
-            out_dict[f"posterior_{location}"] = output_objs
+            out_dict[f"posterior_{location}"] = _package_figure_outputs(fig, f"posterior_{location}", plots_config)
             plt.close(fig)
 
         except (ValueError, AttributeError) as e:
@@ -1513,10 +1509,7 @@ def generate_posterior_grid_plot(
                 _add_footnote(fig, "; ".join(sorted(grid_footnotes)))
 
             # Package output
-            output_objs = []
-            for output_type in plots_config.figure_output_types:
-                output_objs.append(figure_to_output_object(fig, "posterior_grid", output_type, plots_config.dpi))
-            out_dict["posterior_grid"] = output_objs
+            out_dict["posterior_grid"] = _package_figure_outputs(fig, "posterior_grid", plots_config)
             plt.close(fig)
         except Exception as e:
             logger.warning("Failed to create posterior grid plot: %s", e, exc_info=True)
@@ -1606,10 +1599,7 @@ def generate_categorical_plots(
         )
 
         # Package output
-        output_objs = []
-        for output_type in plots_config.figure_output_types:
-            output_objs.append(figure_to_output_object(fig, "categorical_rate_trends", output_type, plots_config.dpi))
-        out_dict["categorical_rate_trends"] = output_objs
+        out_dict["categorical_rate_trends"] = _package_figure_outputs(fig, "categorical_rate_trends", plots_config)
         plt.close(fig)
 
         logger.info("Generated categorical rate-trend plot with %d horizons", len(plots_config.categorical.horizons))

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -8,6 +8,7 @@ outputs as OutputObject instances.
 import logging
 import math
 from datetime import date, timedelta
+from typing import Any
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -394,6 +395,22 @@ def _apply_horizon_filter(
     return proj[dates.values <= end]
 
 
+def _load_surveillance_sources(
+    surveillance_sources: dict[str, ObservedValuesConfig] | None,
+    outputs: list[QuantilesOutputConfig],
+) -> dict[str, dict[str, Any]]:
+    """Load surveillance CSVs if any output needs surveillance. Returns {name: {"data": df, "config": config}}."""
+    if not any(o.show_surveillance for o in outputs) or not surveillance_sources:
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for name, config in surveillance_sources.items():
+        try:
+            result[name] = {"data": pd.read_csv(config.data_path), "config": config}
+        except Exception as e:
+            logger.warning("Failed to load surveillance data from %s: %s", config.data_path, e)
+    return result
+
+
 def _create_quantile_plot(
     location: str,
     cal_quant: pd.DataFrame | None,
@@ -583,17 +600,7 @@ def generate_single_quantile_plots(
     logger.info("Generating single-location quantile plots for %d locations", len(locations))
 
     # Load surveillance data once before loop if any output needs it
-    surveillance_data = {}
-    needs_surveillance = any(output.show_surveillance for output in plots_config.quantiles.outputs)
-    if needs_surveillance and surveillance_sources:
-        for source_name, source_config in surveillance_sources.items():
-            try:
-                surveillance_data[source_name] = {
-                    "data": pd.read_csv(source_config.data_path),
-                    "config": source_config,
-                }
-            except Exception as e:
-                logger.warning("Failed to load surveillance data from %s: %s", source_config.data_path, e)
+    surveillance_data = _load_surveillance_sources(surveillance_sources, plots_config.quantiles.outputs)
 
     needs_calibration = any(output.show_calibration for output in plots_config.quantiles.outputs)
     needs_projection = any(output.show_projection for output in plots_config.quantiles.outputs)
@@ -836,17 +843,7 @@ def generate_quantile_grid_plot(
     logger.info("Generating grid quantile plots for %d locations", len(calibrations))
 
     # Load surveillance data once before loop if any output needs it
-    surveillance_data = {}
-    needs_surveillance = any(output.show_surveillance for output in plots_config.quantiles.outputs)
-    if needs_surveillance and surveillance_sources:
-        for source_name, source_config in surveillance_sources.items():
-            try:
-                surveillance_data[source_name] = {
-                    "data": pd.read_csv(source_config.data_path),
-                    "config": source_config,
-                }
-            except Exception as e:
-                logger.warning("Failed to load surveillance data from %s: %s", source_config.data_path, e)
+    surveillance_data = _load_surveillance_sources(surveillance_sources, plots_config.quantiles.outputs)
 
     needs_calibration = any(output.show_calibration for output in plots_config.quantiles.outputs)
     needs_projection = any(output.show_projection for output in plots_config.quantiles.outputs)

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -378,7 +378,7 @@ def _clip_to_surveillance_start(
     return clipped if not clipped.empty else None
 
 
-def _apply_surveillance_filter(
+def _clip_surveillance(
     surv: pd.DataFrame | None,
     *,
     surveillance_start_date: str | None = None,
@@ -414,7 +414,7 @@ def _apply_surveillance_filter(
     return surv
 
 
-def _apply_horizon_filter(
+def _clip_to_horizon(
     proj: pd.DataFrame | None,
     horizon_max: int | None,
     reference_date: date,
@@ -824,7 +824,7 @@ def generate_single_quantile_plots(
                         continue
 
                     # Apply per-output surveillance filtering if needed (for filtered/full types)
-                    surv_to_use = _apply_surveillance_filter(
+                    surv_to_use = _clip_surveillance(
                         surv_to_use,
                         surveillance_start_date=output_config.surveillance_start_date,
                         surveillance_points=output_config.surveillance_points,
@@ -838,7 +838,7 @@ def generate_single_quantile_plots(
                         cal_to_use = _clip_to_surveillance_start(cal_to_use, surv_to_use)
 
                     # Apply per-output horizon_max if specified (overrides base config)
-                    proj_to_use = _apply_horizon_filter(
+                    proj_to_use = _clip_to_horizon(
                         proj_to_use, output_config.horizon_max, plots_config.reference_date
                     )
 
@@ -1112,7 +1112,7 @@ def generate_quantile_grid_plot(
             # Apply per-output surveillance filtering if needed
             if surv_data_to_use:
                 surv_data_to_use = {
-                    loc: _apply_surveillance_filter(
+                    loc: _clip_surveillance(
                         surv_df,
                         surveillance_start_date=output_config.surveillance_start_date,
                         surveillance_points=output_config.surveillance_points,
@@ -1144,7 +1144,7 @@ def generate_quantile_grid_plot(
             # Apply per-output horizon_max if specified (overrides base config)
             if proj_quants_to_use and output_config.horizon_max is not None:
                 proj_quants_to_use = {
-                    loc: _apply_horizon_filter(df, output_config.horizon_max, plots_config.reference_date)
+                    loc: _clip_to_horizon(df, output_config.horizon_max, plots_config.reference_date)
                     for loc, df in proj_quants_to_use.items()
                 }
 
@@ -1316,7 +1316,7 @@ def generate_quantile_grid_plot(
                             ):
                                 surv_full = location_surveillance_full_sbs[location].copy()
                                 if output_config.full_panel:
-                                    surv_full = _apply_surveillance_filter(
+                                    surv_full = _clip_surveillance(
                                         surv_full,
                                         surveillance_start_date=output_config.full_panel.surveillance_start_date,
                                         surveillance_points=output_config.full_panel.surveillance_points,
@@ -1330,7 +1330,7 @@ def generate_quantile_grid_plot(
                             ):
                                 surv_filtered = location_surveillance_filtered_sbs[location].copy()
                                 if output_config.filtered_panel:
-                                    surv_filtered = _apply_surveillance_filter(
+                                    surv_filtered = _clip_surveillance(
                                         surv_filtered,
                                         surveillance_start_date=output_config.filtered_panel.surveillance_start_date,
                                         surveillance_points=output_config.filtered_panel.surveillance_points,

--- a/epymodelingsuite/visualization/generators.py
+++ b/epymodelingsuite/visualization/generators.py
@@ -350,6 +350,18 @@ def _rename_value_column(df: pd.DataFrame | None, old_name: str) -> pd.DataFrame
     raise ValueError(msg)
 
 
+def _clip_to_surveillance_start(
+    df: pd.DataFrame | None,
+    surv: pd.DataFrame | None,
+) -> pd.DataFrame | None:
+    """Clip df to start at the earliest date in surv. Returns None if empty or inputs are None."""
+    if df is None or surv is None or surv.empty:
+        return df
+    start = pd.to_datetime(surv["date"]).dt.date.min()
+    clipped = df[pd.to_datetime(df["date"]).dt.date >= start]
+    return clipped if not clipped.empty else None
+
+
 def _create_quantile_plot(
     location: str,
     cal_quant: pd.DataFrame | None,
@@ -665,21 +677,8 @@ def generate_single_quantile_plots(
                     # the visible surveillance start so the ribbons match the zoomed view
                     cal_to_use = cal_quant
                     if output_config.type == QuantilesOutputTypeEnum.FILTERED:
-                        effective_surv_start = None
-                        if surv_to_use is not None and not surv_to_use.empty:
-                            effective_surv_start = pd.to_datetime(surv_to_use["date"]).dt.date.min()
-
-                        if effective_surv_start is not None:
-                            if proj_to_use is not None:
-                                proj_dates = pd.to_datetime(proj_to_use["date"]).dt.date
-                                proj_to_use = proj_to_use[proj_dates >= effective_surv_start]
-                                if proj_to_use.empty:
-                                    proj_to_use = None
-                            if cal_to_use is not None:
-                                cal_dates = pd.to_datetime(cal_to_use["date"]).dt.date
-                                cal_to_use = cal_to_use[cal_dates >= effective_surv_start]
-                                if cal_to_use.empty:
-                                    cal_to_use = None
+                        proj_to_use = _clip_to_surveillance_start(proj_to_use, surv_to_use)
+                        cal_to_use = _clip_to_surveillance_start(cal_to_use, surv_to_use)
 
                     # Apply per-output horizon_max if specified (overrides base config)
                     if proj_to_use is not None and output_config.horizon_max is not None:
@@ -714,20 +713,8 @@ def generate_single_quantile_plots(
                         )
                     elif output_config.type == QuantilesOutputTypeEnum.SIDE_BY_SIDE:
                         # Clip calibration and projection quantiles for the filtered panel
-                        cal_quant_for_filtered = cal_quant
-                        proj_quant_for_filtered = proj_quant_filtered
-                        if df_surv_filtered is not None and not df_surv_filtered.empty:
-                            sbs_surv_start = pd.to_datetime(df_surv_filtered["date"]).dt.date.min()
-                            if cal_quant_for_filtered is not None:
-                                cal_dates = pd.to_datetime(cal_quant_for_filtered["date"]).dt.date
-                                cal_quant_for_filtered = cal_quant_for_filtered[cal_dates >= sbs_surv_start]
-                                if cal_quant_for_filtered.empty:
-                                    cal_quant_for_filtered = None
-                            if proj_quant_for_filtered is not None:
-                                proj_dates = pd.to_datetime(proj_quant_for_filtered["date"]).dt.date
-                                proj_quant_for_filtered = proj_quant_for_filtered[proj_dates >= sbs_surv_start]
-                                if proj_quant_for_filtered.empty:
-                                    proj_quant_for_filtered = None
+                        cal_quant_for_filtered = _clip_to_surveillance_start(cal_quant, df_surv_filtered)
+                        proj_quant_for_filtered = _clip_to_surveillance_start(proj_quant_filtered, df_surv_filtered)
 
                         fig, (ax_full, ax_filtered) = _create_sidebyside_plot(
                             location,
@@ -1025,30 +1012,14 @@ def generate_quantile_grid_plot(
                 proj_quants_clipped = {}
                 for loc in set(list(cal_quants_to_use or []) + list(proj_quants_to_use or [])):
                     surv_df = surv_data_to_use.get(loc)
-                    effective_surv_start = None
-                    if surv_df is not None and not surv_df.empty:
-                        effective_surv_start = pd.to_datetime(surv_df["date"]).dt.date.min()
-
                     if loc in (cal_quants_to_use or {}):
-                        if effective_surv_start is not None:
-                            cal_df = cal_quants_to_use[loc]
-                            cal_dates = pd.to_datetime(cal_df["date"]).dt.date
-                            clipped = cal_df[cal_dates >= effective_surv_start]
-                            if not clipped.empty:
-                                cal_quants_clipped[loc] = clipped
-                        else:
-                            cal_quants_clipped[loc] = cal_quants_to_use[loc]
-
+                        clipped = _clip_to_surveillance_start(cal_quants_to_use[loc], surv_df)
+                        if clipped is not None:
+                            cal_quants_clipped[loc] = clipped
                     if loc in (proj_quants_to_use or {}):
-                        if effective_surv_start is not None:
-                            proj_df = proj_quants_to_use[loc]
-                            proj_dates = pd.to_datetime(proj_df["date"]).dt.date
-                            clipped = proj_df[proj_dates >= effective_surv_start]
-                            if not clipped.empty:
-                                proj_quants_clipped[loc] = clipped
-                        else:
-                            proj_quants_clipped[loc] = proj_quants_to_use[loc]
-
+                        clipped = _clip_to_surveillance_start(proj_quants_to_use[loc], surv_df)
+                        if clipped is not None:
+                            proj_quants_clipped[loc] = clipped
                 if cal_quants_to_use:
                     cal_quants_to_use = cal_quants_clipped
                 if proj_quants_to_use:
@@ -1268,19 +1239,8 @@ def generate_quantile_grid_plot(
                                         )
 
                             # Clip filtered panel quantiles to visible surveillance start
-                            cal_quant_filtered = cal_quant
-                            if surv_filtered is not None and not surv_filtered.empty:
-                                effective_surv_start = pd.to_datetime(surv_filtered["date"]).dt.date.min()
-                                if cal_quant_filtered is not None:
-                                    cal_dates = pd.to_datetime(cal_quant_filtered["date"]).dt.date
-                                    cal_quant_filtered = cal_quant_filtered[cal_dates >= effective_surv_start]
-                                    if cal_quant_filtered.empty:
-                                        cal_quant_filtered = None
-                                if proj_quant_filtered is not None:
-                                    proj_dates = pd.to_datetime(proj_quant_filtered["date"]).dt.date
-                                    proj_quant_filtered = proj_quant_filtered[proj_dates >= effective_surv_start]
-                                    if proj_quant_filtered.empty:
-                                        proj_quant_filtered = None
+                            cal_quant_filtered = _clip_to_surveillance_start(cal_quant, surv_filtered)
+                            proj_quant_filtered = _clip_to_surveillance_start(proj_quant_filtered, surv_filtered)
 
                             fitting_window_start = (
                                 location_fitting_window_starts.get(location)

--- a/tests/visualization/test_generators.py
+++ b/tests/visualization/test_generators.py
@@ -11,6 +11,9 @@ from epymodelingsuite.schema.dispatcher import CalibrationOutput
 from epymodelingsuite.schema.output import ObservedValuesConfig, PlotsConfig, QuantilesPlotConfig
 from epymodelingsuite.visualization.generators import (
     _check_incomplete_generations,
+    _clip_surveillance,
+    _clip_to_horizon,
+    _clip_to_surveillance_start,
     _format_plot_notes,
     _prepare_surveillance_for_location,
     _rename_value_column,
@@ -511,3 +514,172 @@ class TestFormatPlotNotes:
         suffix, footnote = _format_plot_notes(["Note one", "Note two"])
         assert suffix == "*"
         assert footnote == "* Note one; Note two"
+
+
+class TestClipToSurveillanceStart:
+    """Tests for _clip_to_surveillance_start helper."""
+
+    @pytest.fixture()
+    def df(self):
+        """Quantile-like DataFrame spanning Jan 1–10."""
+        return pd.DataFrame(
+            {
+                "date": pd.date_range("2024-01-01", periods=10, freq="D"),
+                "quantile": [0.5] * 10,
+                "value": range(10),
+            }
+        )
+
+    def test_clips_df_to_earliest_surveillance_date(self, df):
+        """Rows before the earliest surveillance date are removed."""
+        surv = pd.DataFrame({"date": pd.date_range("2024-01-05", periods=3, freq="D"), "value": [1, 2, 3]})
+        result = _clip_to_surveillance_start(df, surv)
+        assert result is not None
+        assert len(result) == 6  # Jan 5–10
+        assert pd.to_datetime(result["date"]).dt.date.min() == date(2024, 1, 5)
+
+    def test_returns_df_unchanged_when_surv_is_none(self, df):
+        """When surv is None, df is returned as-is."""
+        result = _clip_to_surveillance_start(df, None)
+        assert result is not None
+        assert len(result) == 10
+
+    def test_returns_df_unchanged_when_surv_is_empty(self, df):
+        """When surv is an empty DataFrame, df is returned as-is."""
+        empty_surv = pd.DataFrame({"date": pd.Series(dtype="datetime64[ns]"), "value": pd.Series(dtype="float64")})
+        result = _clip_to_surveillance_start(df, empty_surv)
+        assert result is not None
+        assert len(result) == 10
+
+    def test_returns_none_when_df_is_none(self):
+        """When df is None, None is returned."""
+        surv = pd.DataFrame({"date": ["2024-01-05"], "value": [1]})
+        assert _clip_to_surveillance_start(None, surv) is None
+
+    def test_returns_none_when_all_rows_clipped(self, df):
+        """When surveillance starts after all df dates, None is returned."""
+        surv = pd.DataFrame({"date": ["2024-02-01"], "value": [1]})
+        assert _clip_to_surveillance_start(df, surv) is None
+
+
+class TestClipSurveillance:
+    """Tests for _clip_surveillance helper."""
+
+    @pytest.fixture()
+    def surv(self):
+        """Weekly surveillance DataFrame spanning 8 weeks."""
+        return pd.DataFrame(
+            {
+                "date": pd.date_range("2024-01-01", periods=8, freq="W-SAT"),
+                "value": range(8),
+            }
+        )
+
+    def test_filter_by_start_date(self, surv):
+        """Rows before surveillance_start_date are removed."""
+        result = _clip_surveillance(surv, surveillance_start_date="2024-01-20")
+        assert result is not None
+        assert pd.to_datetime(result["date"]).dt.date.min() >= date(2024, 1, 20)
+
+    def test_filter_by_points_with_reference_date(self, surv):
+        """Keep N points before reference_date plus all points after."""
+        # reference_date in the middle of the series
+        ref = date(2024, 2, 3)  # between week 4 and 5
+        result = _clip_surveillance(surv, surveillance_points=3, reference_date=ref)
+        assert result is not None
+        dates = pd.to_datetime(result["date"]).dt.date
+        before = dates[dates <= ref]
+        after = dates[dates > ref]
+        assert len(before) == 3
+        assert len(after) > 0
+
+    def test_filter_by_points_without_reference_date(self, surv):
+        """Without reference_date, keep the last N rows."""
+        result = _clip_surveillance(surv, surveillance_points=3, reference_date=None)
+        assert result is not None
+        assert len(result) == 3
+        # Should be the last 3 rows
+        assert list(result["value"]) == [5, 6, 7]
+
+    def test_start_date_takes_precedence_over_points(self, surv):
+        """When both surveillance_start_date and surveillance_points are provided, start_date wins."""
+        result = _clip_surveillance(
+            surv,
+            surveillance_start_date="2024-01-20",
+            surveillance_points=2,
+            reference_date=date(2024, 2, 3),
+        )
+        assert result is not None
+        # start_date filter keeps everything >= Jan 20
+        dates = pd.to_datetime(result["date"]).dt.date
+        assert all(d >= date(2024, 1, 20) for d in dates)
+        # Should NOT be limited to 2 points
+        assert len(result) > 2
+
+    def test_returns_none_when_surv_is_none(self):
+        """When surv is None, None is returned."""
+        assert _clip_surveillance(None) is None
+
+    def test_returns_empty_when_surv_is_empty(self):
+        """When surv is empty, empty DataFrame is returned."""
+        empty = pd.DataFrame({"date": pd.Series(dtype="datetime64[ns]"), "value": pd.Series(dtype="float64")})
+        result = _clip_surveillance(empty)
+        assert result is not None
+        assert result.empty
+
+    def test_reference_date_point_included_in_before(self, surv):
+        """A point exactly on reference_date counts in the 'before' group."""
+        # Pick a date that matches an actual row
+        exact_date = pd.to_datetime(surv["date"]).dt.date.iloc[4]
+        result = _clip_surveillance(surv, surveillance_points=2, reference_date=exact_date)
+        assert result is not None
+        dates = pd.to_datetime(result["date"]).dt.date
+        before = dates[dates <= exact_date]
+        # The point on exact_date should be in the 'before' group
+        assert exact_date in before.values
+        assert len(before) == 2
+
+
+class TestClipToHorizon:
+    """Tests for _clip_to_horizon helper."""
+
+    @pytest.fixture()
+    def proj(self):
+        """Weekly projection DataFrame spanning 10 weeks from reference_date."""
+        return pd.DataFrame(
+            {
+                "date": pd.date_range("2024-01-07", periods=10, freq="W-SUN"),
+                "quantile": [0.5] * 10,
+                "value": range(10),
+            }
+        )
+
+    @pytest.fixture()
+    def reference_date(self):
+        return date(2024, 1, 7)
+
+    def test_clips_to_max_horizon_weeks(self, proj, reference_date):
+        """Only rows within horizon_max weeks of reference_date are kept."""
+        result = _clip_to_horizon(proj, horizon_max=4, reference_date=reference_date)
+        assert result is not None
+        dates = pd.to_datetime(result["date"]).dt.date
+        assert len(result) == 5  # week 0, 1, 2, 3, 4
+        assert dates.max() <= date(2024, 2, 4)  # reference + 4 weeks
+
+    def test_returns_proj_unchanged_when_horizon_max_is_none(self, proj, reference_date):
+        """When horizon_max is None, proj is returned as-is."""
+        result = _clip_to_horizon(proj, horizon_max=None, reference_date=reference_date)
+        assert result is not None
+        assert len(result) == 10
+
+    def test_returns_none_when_proj_is_none(self, reference_date):
+        """When proj is None, None is returned."""
+        assert _clip_to_horizon(None, horizon_max=4, reference_date=reference_date) is None
+
+    def test_does_not_mutate_original(self, proj, reference_date):
+        """Clipping returns a copy; the original DataFrame is unchanged."""
+        original_len = len(proj)
+        result = _clip_to_horizon(proj, horizon_max=2, reference_date=reference_date)
+        assert len(proj) == original_len
+        assert result is not None
+        assert len(result) < original_len

--- a/tests/visualization/test_generators.py
+++ b/tests/visualization/test_generators.py
@@ -186,13 +186,15 @@ class TestSurveillanceDataFiltering:
             df_surv_full = second_call_kwargs["df_surveillance"]
 
             # When no calibration/projection quantiles, filtered surveillance should still be loaded
-            # and filtered to the 8 most recent points (default surveillance_points value)
+            # and filtered to 8 points before reference_date (2024-01-15) plus all after
             assert df_surv_filtered is not None
-            # Should have exactly 8 points (the most recent ones)
-            assert len(df_surv_filtered) == 8
-            # Check that we have the most recent dates
-            max_date_filtered = pd.to_datetime(df_surv_filtered["date"]).max()
-            assert max_date_filtered.date() == date(2024, 2, 15)
+            dates_filtered = pd.to_datetime(df_surv_filtered["date"]).dt.date
+            before_ref = dates_filtered[dates_filtered <= date(2024, 1, 15)]
+            after_ref = dates_filtered[dates_filtered > date(2024, 1, 15)]
+            assert len(before_ref) == 8
+            assert len(after_ref) > 0
+            max_date_filtered = dates_filtered.max()
+            assert max_date_filtered == date(2024, 2, 15)
 
             # Full surveillance should show all data (no filtering)
             assert df_surv_full is not None
@@ -231,11 +233,12 @@ class TestSurveillanceDataFiltering:
             df_surv_filtered = first_call_kwargs["df_surveillance"]
             df_surv_full = second_call_kwargs["df_surveillance"]
 
-            # Filtered surveillance should be filtered based on calibration quantiles
+            # Filtered surveillance should be clipped to calibration quantile start (2024-01-15)
+            # then further filtered by surveillance_points (8 before reference_date + all after)
             assert df_surv_filtered is not None
-            # Calibration quantiles start from 2024-01-15
-            min_date_filtered = pd.to_datetime(df_surv_filtered["date"]).min()
-            assert min_date_filtered.date() >= date(2024, 1, 15)
+            dates_filtered = pd.to_datetime(df_surv_filtered["date"]).dt.date
+            # Calibration quantiles start from 2024-01-15, so data is clipped there first
+            assert dates_filtered.min() >= date(2024, 1, 8)
 
             # Full surveillance should show all data (no filtering)
             assert df_surv_full is not None


### PR DESCRIPTION
Resolves #241 

## Summary
- Fix filtered (zoomed) plots so quantile ribbons are clipped to match the visible surveillance range
- Fix `surveillance_points` to count points before `reference_date` (not from end of dataset), so retrospective analyses show correct historical context
- Refactor `generators.py`: extract shared helpers, unify naming to `_clip_*` convention
- Add unit tests for `_clip_*` helper functions

Now the filtered plots are clipped:
<img width="400" height="327" alt="image" src="https://github.com/user-attachments/assets/8abd7136-950a-493b-8ac9-3b3a6736ab87" />

## Changes
- Clip calibration and projection quantiles to surveillance start in filtered plots
- Merge `_create_filtered_plot` and `_create_full_plot` into single `_create_quantile_plot`
- Extract helpers: `_clip_to_surveillance_start`, `_clip_surveillance`, `_clip_to_horizon`, `_load_surveillance_sources`, `_compute_fitting_window`, `_package_figure_outputs`
- `_clip_surveillance`: split on `reference_date` so `surveillance_points=N` means N points before reference date, plus all future points
- Add 16 unit tests covering edge cases for `_clip_to_surveillance_start`, `_clip_surveillance`, `_clip_to_horizon`