### PR TITLE
Validate probability distributions during configuration

### DIFF
--- a/epymodelingsuite/config_loader.py
+++ b/epymodelingsuite/config_loader.py
@@ -61,7 +61,12 @@ def load_sampling_config_from_file(path: str) -> SamplingConfig:
     with Path(path).open() as f:
         raw = yaml.safe_load(f)
 
-    root = validate_sampling(raw)
+    try:
+        root = validate_sampling(raw)
+    except ValueError as e:
+        msg = f"Invalid sampling configuration file '{path}': {e}"
+        logger.error(msg)  # noqa: TRY400 - log a concise config error without duplicating its traceback
+        raise ValueError(msg) from e
     logger.info("Sampling configuration loaded successfully.")
     return root
 
@@ -85,7 +90,12 @@ def load_calibration_config_from_file(path: str) -> CalibrationConfig:
     with Path(path).open() as f:
         raw = yaml.safe_load(f)
 
-    root = validate_calibration(raw)
+    try:
+        root = validate_calibration(raw)
+    except ValueError as e:
+        msg = f"Invalid calibration configuration file '{path}': {e}"
+        logger.error(msg)  # noqa: TRY400 - log a concise config error without duplicating its traceback
+        raise ValueError(msg) from e
     logger.info("Calibration configuration loaded successfully.")
     return root
 

--- a/epymodelingsuite/dispatcher/builder.py
+++ b/epymodelingsuite/dispatcher/builder.py
@@ -533,11 +533,24 @@ def build_calibration(
         # Parameters and compartments can be None in calibration config
         priors = {}
         if calibration.parameters:
-            priors.update({k: distribution_to_scipy(v.prior) for k, v in calibration.parameters.items()})
+            priors.update(
+                {
+                    k: distribution_to_scipy(v.prior, context=f"calibration parameter '{k}'")
+                    for k, v in calibration.parameters.items()
+                }
+            )
         if calibration.compartments:
-            priors.update({k: distribution_to_scipy(v.prior) for k, v in calibration.compartments.items()})
+            priors.update(
+                {
+                    k: distribution_to_scipy(v.prior, context=f"calibration compartment '{k}'")
+                    for k, v in calibration.compartments.items()
+                }
+            )
         if sampled_start_timespan:
-            priors["start_date"] = distribution_to_scipy(calibration.start_date.prior)
+            priors["start_date"] = distribution_to_scipy(
+                calibration.start_date.prior,
+                context="calibration start_date",
+            )
 
         fixed_parameters = {k: v for k, v in model.parameters.items() if v is not None}
         if calibration.fitting_window.end_date:

--- a/epymodelingsuite/schema/common.py
+++ b/epymodelingsuite/schema/common.py
@@ -4,7 +4,7 @@ import datetime
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class Distribution(BaseModel):
@@ -27,6 +27,15 @@ class Distribution(BaseModel):
     kwargs: dict[str, Any] = Field(
         default_factory=dict, description="Keyword arguments for the distribution initializer"
     )
+
+    @model_validator(mode="after")
+    def validate_distribution_configuration(self) -> "Distribution":
+        """Validate distribution arguments when configuration models are created."""
+        # Import locally because the conversion utility uses Distribution for type checking.
+        from epymodelingsuite.utils.distributions import validate_distribution
+
+        validate_distribution(self)
+        return self
 
 
 class DateParameter(BaseModel):

--- a/epymodelingsuite/utils/__init__.py
+++ b/epymodelingsuite/utils/__init__.py
@@ -17,7 +17,7 @@ from .common import parse_timedelta
 from .config import identify_config_type
 from .data import fetch_hhs_hospitalizations
 from .distance import wrmse
-from .distributions import distribution_to_scipy
+from .distributions import distribution_to_scipy, validate_distribution
 from .epydemix_data import EPYDEMIX_DATA_VERSION, get_available_locations, load_epydemix_population
 from .expression_eval import RetrieveName, SafeEvalVisitor, safe_eval
 from .formatting import format_data_size, format_duration
@@ -35,6 +35,7 @@ __all__ = [
     "wrmse",
     # Distribution utilities
     "distribution_to_scipy",
+    "validate_distribution",
     # epydemix-data (pinned)
     "EPYDEMIX_DATA_VERSION",
     "get_available_locations",

--- a/epymodelingsuite/utils/distributions.py
+++ b/epymodelingsuite/utils/distributions.py
@@ -1,23 +1,170 @@
-"""Distribution conversion utilities."""
+"""Distribution validation and conversion utilities."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
 import scipy.stats
 
-from ..schema.common import Distribution
+if TYPE_CHECKING:
+    from epymodelingsuite.schema.common import Distribution
+
+SCALAR_SUPPORT_BOUND_COUNT = 2
 
 
-def distribution_to_scipy(distribution: Distribution):
+def _get_parameter_value(
+    distribution: Distribution,
+    *,
+    name: str,
+    position: int,
+    default: float,
+) -> object:
+    """Get a SciPy parameter supplied as either a keyword or positional argument."""
+    if name in distribution.kwargs:
+        return distribution.kwargs[name]
+    if len(distribution.args) > position:
+        return distribution.args[position]
+    return default
+
+
+def _is_finite_scalar(value: object) -> bool:
+    """Return whether a value is a finite numeric scalar."""
+    try:
+        array = np.asarray(value)
+        return array.ndim == 0 and bool(np.isfinite(array))
+    except TypeError:
+        return False
+
+
+def validate_distribution(  # noqa: C901 - validation is intentionally linear
+    distribution: Distribution,
+    *,
+    context: str | None = None,
+) -> None:
     """
-    Convert a Distribution object to a scipy distribution object.
+    Validate a probability distribution configuration.
+
+    SciPy continuous and discrete scalar random variables are supported. Custom
+    distributions are left unchanged because they are resolved outside SciPy.
+
+    Parameters
+    ----------
+    distribution : Distribution
+        Distribution configuration to validate.
+    context : str, optional
+        Description of where the distribution is used, included in errors.
+
+    Raises
+    ------
+    ValueError
+        If the distribution type, name, or parameters are invalid.
+    """
+    prefix = f"{context}: " if context else ""
+
+    # Custom distributions are validated by their own implementation rather than
+    # against SciPy's random-variable API.
+    if distribution.type == "custom":
+        return
+    if distribution.type != "scipy":
+        msg = f"{prefix}Unsupported distribution type {distribution.type!r}"
+        raise ValueError(msg)
+
+    # Resolve only SciPy's scalar continuous and discrete random-variable
+    # generators. Other scipy.stats utilities and multivariate distributions do
+    # not match the scalar parameter interface expected by the samplers.
+    dist_class = getattr(scipy.stats, distribution.name, None)
+    if dist_class is None:
+        msg = f"{prefix}Unknown scipy.stats distribution '{distribution.name}'"
+        raise ValueError(msg)
+    if not isinstance(dist_class, (scipy.stats.rv_continuous, scipy.stats.rv_discrete)):
+        msg = (
+            f"{prefix}scipy.stats.{distribution.name} is not a supported scalar continuous or discrete random variable"
+        )
+        raise ValueError(msg)  # noqa: TRY004 - the configured value, rather than a Python type, is invalid
+
+    # Freezing checks argument names, argument counts, and required shape
+    # parameters. SciPy still permits some invalid values (such as scale=0), so
+    # the explicit checks below remain necessary.
+    details = f"args={distribution.args!r}, kwargs={distribution.kwargs!r}"
+    try:
+        frozen_distribution = dist_class(*distribution.args, **distribution.kwargs)
+    except (TypeError, ValueError) as e:
+        msg = f"{prefix}Invalid arguments for scipy.stats.{distribution.name} ({details}): {e}"
+        raise ValueError(msg) from e
+
+    # Both continuous and discrete SciPy variables accept loc after their shape
+    # arguments. Calibration priors must use a finite scalar location.
+    loc = _get_parameter_value(
+        distribution,
+        name="loc",
+        position=dist_class.numargs,
+        default=0,
+    )
+    if not _is_finite_scalar(loc):
+        msg = (
+            f"{prefix}Invalid scipy.stats.{distribution.name} location: loc must be a finite scalar; "
+            f"got {loc!r} ({details})"
+        )
+        raise ValueError(msg)
+
+    # Scale is part of the continuous-variable API only. Its positional index is
+    # immediately after loc, following any distribution-specific shape arguments.
+    if isinstance(dist_class, scipy.stats.rv_continuous):
+        scale = _get_parameter_value(
+            distribution,
+            name="scale",
+            position=dist_class.numargs + 1,
+            default=1,
+        )
+        if not _is_finite_scalar(scale) or scale <= 0:
+            help_text = ""
+            if distribution.name == "uniform":
+                help_text = " For scipy.stats.uniform, arguments are [loc, scale], where upper bound = loc + scale."
+            msg = (
+                f"{prefix}Invalid scipy.stats.{distribution.name} scale: scale must be a finite scalar "
+                f"greater than 0; got {scale!r} ({details}).{help_text}"
+            )
+            raise ValueError(msg)
+
+    # SciPy's support calculation applies distribution-specific shape checks
+    # without sampling. Invalid combinations return NaN bounds; vectorized bounds
+    # indicate a non-scalar distribution, which the current samplers do not support.
+    try:
+        support = np.asarray(frozen_distribution.support(), dtype=float)
+    except (TypeError, ValueError) as e:
+        msg = f"{prefix}Could not validate scipy.stats.{distribution.name} support ({details}): {e}"
+        raise ValueError(msg) from e
+
+    if support.size != SCALAR_SUPPORT_BOUND_COUNT:
+        msg = (
+            f"{prefix}scipy.stats.{distribution.name} must define a scalar random variable; "
+            f"received vectorized parameters ({details})"
+        )
+        raise ValueError(msg)
+    if np.any(np.isnan(support)):
+        msg = (
+            f"{prefix}Invalid parameters for scipy.stats.{distribution.name}: "
+            f"the configured distribution has no valid support ({details})"
+        )
+        raise ValueError(msg)
+
+
+def distribution_to_scipy(distribution: Distribution, *, context: str | None = None) -> object:
+    """
+    Convert a Distribution object to a validated scipy distribution object.
 
     Parameters
     ----------
     distribution : Distribution
         A Distribution instance containing name, args, and kwargs for the scipy distribution.
+    context : str, optional
+        Description of where the distribution is used, included in errors.
 
     Returns
     -------
     scipy.stats distribution object
-        The scipy distribution object created from the Distribution parameters.
+        The frozen scipy distribution object created from the Distribution parameters.
 
     Examples
     --------
@@ -30,11 +177,12 @@ def distribution_to_scipy(distribution: Distribution):
     >>> scipy_dist = distribution_to_scipy(dist_config)
     >>> scipy_dist.rvs(10)  # Generate 10 random samples from uniform distribution
     """
-    if distribution.type == "scipy":
-        # Get the distribution class from scipy.stats
-        dist_class = getattr(scipy.stats, distribution.name)
+    validate_distribution(distribution, context=context)
 
-        # Create the distribution object with args and kwargs
-        kwargs = distribution.kwargs or {}
-        dist = dist_class(*distribution.args, **kwargs)
-    return dist
+    if distribution.type != "scipy":
+        prefix = f"{context}: " if context else ""
+        msg = f"{prefix}Cannot convert distribution type {distribution.type!r} to scipy"
+        raise ValueError(msg)
+
+    dist_class = getattr(scipy.stats, distribution.name)
+    return dist_class(*distribution.args, **distribution.kwargs)

--- a/tests/schema/test_distribution_validation.py
+++ b/tests/schema/test_distribution_validation.py
@@ -1,0 +1,119 @@
+"""Tests for distribution validation through shared configuration schemas."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.logging import LogCaptureFixture
+
+from epymodelingsuite.config_loader import load_calibration_config_from_file
+from epymodelingsuite.schema.calibration import CalibrationConfig
+from epymodelingsuite.schema.sampling import SamplingConfig
+
+
+def _calibration_config_with_prior(prior: dict) -> dict:
+    """Create a minimal calibration configuration containing one prior."""
+    return {
+        "modelset": {
+            "population_names": ["US-CA"],
+            "calibration": {
+                "strategy": {"name": "SMC"},
+                "observed_data_path": "data.csv",
+                "comparison": [
+                    {
+                        "observed_date_column": "date",
+                        "observed_value_column": "value",
+                        "simulation": ["I_to_R"],
+                    }
+                ],
+                "fitting_window": {"start_date": "2024-01-01", "end_date": "2024-02-01"},
+                "parameters": {"alpha": {"prior": prior}},
+            },
+        }
+    }
+
+
+def test_calibration_prior_error_includes_configuration_path() -> None:
+    """Calibration errors identify the exact prior containing invalid scale."""
+    config = _calibration_config_with_prior(
+        {"type": "scipy", "name": "uniform", "args": [1.0, 0.0]},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"(?s)modelset\.calibration\.parameters\.alpha\.prior.*scale must be a finite scalar greater than 0",
+    ):
+        CalibrationConfig(**config)
+
+
+def test_sampling_distribution_uses_shared_validation() -> None:
+    """Sampling distributions receive the same early validation as priors."""
+    config = {
+        "modelset": {
+            "population_names": ["US-CA"],
+            "sampling": {
+                "samplers": [
+                    {
+                        "strategy": "LHS",
+                        "n_samples": 10,
+                        "parameters": ["alpha"],
+                    }
+                ],
+                "parameters": {
+                    "alpha": {
+                        "distribution": {
+                            "type": "scipy",
+                            "name": "uniform",
+                            "kwargs": {"loc": 1.0, "scale": 0.0},
+                        }
+                    }
+                },
+            },
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match=r"(?s)modelset\.sampling\.parameters\.alpha\.distribution.*scale must be a finite scalar greater than 0",
+    ):
+        SamplingConfig(**config)
+
+
+def test_loader_logs_filename_and_prior_error(tmp_path: Path, caplog: LogCaptureFixture) -> None:
+    """The loader logs one actionable error with filename and prior path."""
+    config_path = tmp_path / "invalid-calibration.yml"
+    config_path.write_text(
+        """
+modelset:
+  population_names: [US-CA]
+  calibration:
+    strategy:
+      name: SMC
+    observed_data_path: data.csv
+    comparison:
+      - observed_date_column: date
+        observed_value_column: value
+        simulation: [I_to_R]
+    fitting_window:
+      start_date: 2024-01-01
+      end_date: 2024-02-01
+    parameters:
+      alpha:
+        prior:
+          type: scipy
+          name: uniform
+          args: [1.0, 0.0]
+"""
+    )
+
+    with caplog.at_level(logging.ERROR), pytest.raises(ValueError, match=r"invalid-calibration\.yml"):
+        load_calibration_config_from_file(str(config_path))
+
+    assert "modelset.calibration.parameters.alpha.prior" in caplog.text  # noqa: S101
+    assert "upper bound = loc + scale" in caplog.text  # noqa: S101

--- a/tests/utils/test_distributions.py
+++ b/tests/utils/test_distributions.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from epymodelingsuite.schema.common import Distribution
-from epymodelingsuite.utils.distributions import distribution_to_scipy
+from epymodelingsuite.utils.distributions import distribution_to_scipy, validate_distribution
 
 
 class TestDistributionToScipy:
@@ -56,20 +56,62 @@ class TestDistributionToScipy:
         assert all(0 <= s <= 1 for s in samples)
 
     def test_invalid_type_raises_error(self):
-        """Non-scipy type raises clear error (not UnboundLocalError)."""
+        """Custom distributions cannot be converted to SciPy distributions."""
         dist_config = Distribution(type="custom", name="foo", args=[])
 
-        # Currently raises UnboundLocalError - this test documents expected behavior
-        # The function should raise ValueError with a helpful message
-        with pytest.raises((ValueError, UnboundLocalError)):
+        with pytest.raises(ValueError, match="Cannot convert distribution type 'custom' to scipy"):
             distribution_to_scipy(dist_config)
 
-    def test_invalid_name_raises_attribute_error(self):
-        """Invalid scipy distribution name raises AttributeError."""
-        dist_config = Distribution(type="scipy", name="not_a_distribution", args=[])
+    def test_invalid_name_rejected_during_configuration(self):
+        """Invalid SciPy distribution names fail during model validation."""
+        with pytest.raises(ValueError, match=r"Unknown scipy\.stats distribution 'not_a_distribution'"):
+            Distribution(type="scipy", name="not_a_distribution", args=[])
 
-        with pytest.raises(AttributeError):
-            distribution_to_scipy(dist_config)
+    def test_non_distribution_scipy_name_rejected(self):
+        """Other scipy.stats functions are not accepted as random variables."""
+        with pytest.raises(ValueError, match="not a supported scalar continuous or discrete random variable"):
+            Distribution(type="scipy", name="describe", args=[])
+
+    def test_uniform_zero_scale_rejected_during_configuration(self):
+        """A zero-scale uniform prior is rejected before calibration starts."""
+        with pytest.raises(
+            ValueError,
+            match=r"scale must be a finite scalar greater than 0.*upper bound = loc \+ scale",
+        ):
+            Distribution(type="scipy", name="uniform", args=[1.0, 0.0])
+
+    def test_negative_keyword_scale_rejected_during_configuration(self):
+        """Scale validation supports keyword arguments."""
+        with pytest.raises(ValueError, match="scale must be a finite scalar greater than 0"):
+            Distribution(type="scipy", name="norm", kwargs={"loc": 0, "scale": -1})
+
+    @pytest.mark.parametrize("scale", [float("inf"), float("nan")])
+    def test_non_finite_scale_rejected(self, scale):
+        """Continuous distributions require finite scale values."""
+        with pytest.raises(ValueError, match="scale must be a finite scalar greater than 0"):
+            Distribution(type="scipy", name="norm", kwargs={"scale": scale})
+
+    def test_non_finite_location_rejected(self):
+        """All supported distributions require finite scalar locations."""
+        with pytest.raises(ValueError, match="loc must be a finite scalar"):
+            Distribution(type="scipy", name="poisson", kwargs={"mu": 2, "loc": float("inf")})
+
+    def test_invalid_discrete_parameters_rejected(self):
+        """Distribution-specific discrete constraints are checked through support."""
+        with pytest.raises(ValueError, match=r"Invalid parameters for scipy\.stats\.randint"):
+            Distribution(type="scipy", name="randint", args=[1, 1])
+
+    def test_invalid_continuous_shape_parameters_rejected(self):
+        """Distribution-specific continuous shape constraints are checked through support."""
+        with pytest.raises(ValueError, match=r"Invalid parameters for scipy\.stats\.beta"):
+            Distribution(type="scipy", name="beta", args=[-1, 2])
+
+    def test_validate_distribution_includes_runtime_context(self):
+        """Defensive validation errors identify the parameter being converted."""
+        dist_config = Distribution.model_construct(type="scipy", name="uniform", args=[1.0, 0.0], kwargs={})
+
+        with pytest.raises(ValueError, match=r"calibration parameter 'alpha'.*scale"):
+            validate_distribution(dist_config, context="calibration parameter 'alpha'")
 
     def test_default_type_is_scipy(self):
         """Distribution with default type (scipy) works correctly."""


### PR DESCRIPTION
## Summary

Validate SciPy distributions before sampling or calibration starts. This catches priors such as `uniform(loc=1.0, scale=0.0)` during configuration loading instead of allowing the zero scale to cause SciPy's `invalid value encountered in divide` warning during calibration. A `loc` of zero remains valid.

## Changes

- Add shared validation for continuous and discrete scalar distributions.
- Validate distributions during configuration parsing and runtime conversion.
- Add contextual loader errors and regression coverage for invalid priors.

## Tests

- `uv run pytest -q tests/utils/test_distributions.py tests/schema/test_distribution_validation.py tests/test_calibration_validation.py tests/schema/test_calibration.py`
- 61 passed.
- Broader suite: 1001 passed with the unrelated population conservation test excluded.